### PR TITLE
fix: ad-hoc sign with correct bundle identifier for Accessibility permissions

### DIFF
--- a/build_release.sh
+++ b/build_release.sh
@@ -82,17 +82,22 @@ echo "📦 Copying to ./Release/XKey.app..."
 rm -rf Release/XKey.app
 cp -R "./build/Build/Products/Release/XKey.app" Release/
 
-# Verify code signature
-if [ "$ENABLE_CODESIGN" = true ]; then
-    echo "🔍 Verifying code signature..."
-    codesign -vvv --deep --strict Release/XKey.app
-    echo "✅ Code signature verified"
-    
-    # Display signature info
-    echo ""
-    echo "📝 Signature details:"
-    codesign -dvvv Release/XKey.app 2>&1 | grep -E "(Authority|Identifier|TeamIdentifier|Timestamp)"
+# Ad-hoc sign with correct identifier (required for Accessibility permissions)
+if [ "$ENABLE_CODESIGN" = false ]; then
+    echo "🔐 Ad-hoc signing with correct bundle identifier..."
+    codesign --force --deep --sign - --identifier "$BUNDLE_ID" Release/XKey.app
+    echo "✅ Ad-hoc signed with identifier: $BUNDLE_ID"
 fi
+
+# Verify code signature
+echo "🔍 Verifying code signature..."
+codesign -vvv --deep --strict Release/XKey.app
+echo "✅ Code signature verified"
+
+# Display signature info
+echo ""
+echo "📝 Signature details:"
+codesign -dvvv Release/XKey.app 2>&1 | grep -E "(Authority|Identifier|TeamIdentifier|Timestamp)"
 
 # Notarization (optional)
 if [ "$ENABLE_NOTARIZE" = true ] && [ "$ENABLE_CODESIGN" = true ]; then


### PR DESCRIPTION
## Summary

Fix Accessibility permissions not working when building without Developer ID certificate.

### Problem

When building with `ENABLE_CODESIGN=false`, the app was signed with linker-signed adhoc signature which uses `XKey` as code signature identifier instead of `com.codetay.XKey` from Info.plist.

This caused macOS TCC (Transparency, Consent, and Control) to not recognize the app correctly when granting Accessibility permissions, because TCC stores permissions by **code signature identifier**, not bundle identifier.

**Before fix:**
```
Identifier=XKey              # Wrong - from linker
CFBundleIdentifier=com.codetay.XKey  # Correct - from Info.plist
```

**After fix:**
```
Identifier=com.codetay.XKey  # Correct - matches bundle identifier
CFBundleIdentifier=com.codetay.XKey
```

### Changes

- Add ad-hoc signing step with explicit `--identifier` flag matching `BUNDLE_ID`
- Always verify and display signature details regardless of signing mode

### Test Plan

- [x] Build with `ENABLE_CODESIGN=false ./build_release.sh`
- [x] Verify code signature shows `Identifier=com.codetay.XKey`
- [x] Add app to System Settings → Privacy & Security → Accessibility
- [x] Confirm app can intercept keyboard events
