### PR TITLE
fix: remove incorrect Chrome address bar fix causing character loss

### DIFF
--- a/XKey/EventHandling/KeyboardEventHandler.swift
+++ b/XKey/EventHandling/KeyboardEventHandler.swift
@@ -199,7 +199,6 @@ class KeyboardEventHandler: EventTapManager.EventTapDelegate {
             // Temporarily disable engine when Option is pressed
             debugLogCallback?("  → Option pressed - temp off engine")
             engine.reset()
-            injector.markNewSession()
             return false
         }
 
@@ -207,23 +206,20 @@ class KeyboardEventHandler: EventTapManager.EventTapDelegate {
         if event.isCommandPressed {
             debugLogCallback?("  → Has Cmd modifier")
             engine.reset()
-            injector.markNewSession()  // Mark as new input session
             return false
         }
-        
+
         // Don't process if Option is pressed and tempOffEngine is NOT enabled
         if event.isOptionPressed && !tempOffEngineEnabled {
             debugLogCallback?("  → Option pressed but tempOffEngine disabled")
             engine.reset()
-            injector.markNewSession()
             return false
         }
-        
+
         // If only Ctrl is pressed and tempOffSpelling is NOT enabled, skip processing
         if event.isControlPressed && !tempOffSpellingEnabled {
             debugLogCallback?("  → Ctrl pressed but tempOffSpelling disabled")
             engine.reset()
-            injector.markNewSession()
             return false
         }
 
@@ -269,7 +265,6 @@ class KeyboardEventHandler: EventTapManager.EventTapDelegate {
         if cursorMovementKeys.contains(keyCode) {
             debugLogCallback?("  → CURSOR MOVEMENT - reset engine")
             engine.reset()
-            injector.markNewSession()
             return event
         }
 
@@ -309,8 +304,6 @@ class KeyboardEventHandler: EventTapManager.EventTapDelegate {
                 // Don't consume - let it pass through
             }
             
-            injector.resetFirstWord()  // Mark that we're no longer on first word
-            injector.resetKeystrokeCount()  // Reset keystroke count for next word
             return event
         }
 
@@ -322,21 +315,10 @@ class KeyboardEventHandler: EventTapManager.EventTapDelegate {
             isUppercase: isUppercase
         )
         debugLogCallback?("  → Engine returned: shouldConsume=\(result.shouldConsume), bs=\(result.backspaceCount), chars=\(result.newCharacters.count)")
-        
-        // Increment keystroke count for Chrome duplicate detection
-        if result.shouldConsume {
-            injector.incrementKeystroke()
-        }
 
         // Handle result
         if result.shouldConsume {
             debugLogCallback?("  → CONSUME: bs=\(result.backspaceCount) chars=\(result.newCharacters.count)")
-
-            // Chrome address bar fix: Check for duplicates BEFORE sending backspaces
-            // Only applies to Chrome address bar, not content area
-            debugLogCallback?("  → Calling Chrome address bar fix...")
-            injector.checkAndFixChromeAddressBarDuplicate(proxy: proxy)
-            debugLogCallback?("  → Chrome fix done")
 
             // Send backspaces with autocomplete fix
             if result.backspaceCount > 0 {
@@ -473,10 +455,9 @@ class KeyboardEventHandler: EventTapManager.EventTapDelegate {
     }
     
     // MARK: - Reset
-    
+
     func reset() {
         engine.reset()
-        injector.markNewSession()  // Mark as new input session
     }
 }
 


### PR DESCRIPTION
## Summary

- Fix character loss when typing Vietnamese in Chrome/Chromium address bar
- Remove incorrect `checkAndFixChromeAddressBarDuplicate()` that sent extra backspaces
- Clean up unused tracking variables and functions

## Problem

When typing Vietnamese in Chrome/Chromium address bar, characters were being lost. For example:
- Typing `thu73` produced `tử` instead of `thử` (missing `h`)
- Typing `To6i` produced `tôi` instead of `Tôi` (missing uppercase)

### Root Cause

The previous Chrome address bar fix (`checkAndFixChromeAddressBarDuplicate`) was sending an extra backspace on every keystroke when `keystrokeCount >= 2` in the first word. This logic was incorrect because:

1. Chrome does NOT duplicate characters when **replacing** a vowel with a toned/accented version (e.g., `u` → `ư`, `ư` → `ử`)
2. The extra backspace was deleting the previous character instead of a "duplicate"

### Debug Log (Before Fix)

```
KEY: 't' code=17
KEY: 'h' code=4
KEY: 'u' code=32
KEY: '7' code=26
  → CONSUME: bs=1 chars=1
  → Chrome fix check: keystrokeCount=1
  → Chrome fix: Wrong timing (need keystrokeCount>=2)  ← Skipped, OK
  → Inject: ư

KEY: '3' code=20
  → CONSUME: bs=1 chars=1
  → Chrome fix check: keystrokeCount=2
  → ✓ Chrome fix: Sending backspace to remove duplicate  ← WRONG! Deleted 'h'
  → Inject: ử

Result: "tử" instead of "thử"
```

## Solution

Removed the incorrect Chrome address bar fix entirely. The autocomplete issue is already handled by the `fixAutocomplete` mechanism using Forward Delete.

### Changes

**CharacterInjector.swift:**
- Removed `isFirstWord`, `keystrokeCount` tracking variables
- Removed `resetFirstWord()`, `markNewSession()`, `resetKeystrokeCount()`, `incrementKeystroke()` functions
- Removed `checkAndFixChromeAddressBarDuplicate()`, `getKeystrokeCount()`, `isInChromeAddressBar()` functions

**KeyboardEventHandler.swift:**
- Removed call to `checkAndFixChromeAddressBarDuplicate()`
- Removed calls to `incrementKeystroke()`, `markNewSession()`, `resetFirstWord()`, `resetKeystrokeCount()`

## Test Plan

- [x] Build successfully with `ENABLE_CODESIGN=false ./build_release.sh`
- [x] Type `thu73` in Chrome address bar → should produce `thử`
- [x] Type `To6i` in Chrome address bar → should produce `Tôi`
- [x] Type `caám` in Chrome address bar → should produce `cám`
- [x] Type normally in Chrome content area → should work correctly
- [x] Type in Spotlight → should work correctly

## Video Evidence

https://github.com/user-attachments/assets/757cc2ce-d237-4fe2-bc60-0c121d6f9b87


