### PR TITLE
Fix: Allow Vietnamese typing when using iPhone Mirroring on macOS

### DIFF
--- a/XKey/EventHandling/KeyboardEventHandler.swift
+++ b/XKey/EventHandling/KeyboardEventHandler.swift
@@ -808,7 +808,6 @@ class KeyboardEventHandler: EventTapManager.EventTapDelegate {
     
     /// Apps that should always pass through all keys (remote devices handle input)
     private static let passthroughApps: Set<String> = [
-        "com.apple.ScreenContinuity",  // iPhone Mirroring - iOS device handles text input
         "com.apple.iphonesimulator"    // Simulator - iOS simulator handles text input
     ]
     


### PR DESCRIPTION
## Description

This fix resolves an issue where Vietnamese typing was not working when using iPhone Mirroring on macOS.

## Root Cause

The  bundle ID (iPhone Mirroring) was incorrectly included in the  set, which caused all key events to bypass Vietnamese input processing.

## Fix

Removed  from the passthroughApps list while keeping  for iOS simulator compatibility.

## Testing

- Verified that the change allows Vietnamese input to work normally when using iPhone Mirroring
- The fix is minimal and targeted, affecting only the specific use case