### PR TITLE
feat: add emoji option for status bar icon

### DIFF
--- a/XKey/Core/Models/Preferences.swift
+++ b/XKey/Core/Models/Preferences.swift
@@ -11,11 +11,13 @@ import Cocoa
 enum MenuBarIconStyle: String, Codable, CaseIterable {
     case x = "X"
     case v = "V"
+    case icon = "🇻🇳"
     
     var displayName: String {
         switch self {
         case .x: return "Chữ X"
         case .v: return "Chữ V"
+        case .icon: return "Emoji 🇻🇳 / 🇬🇧"
         }
     }
 }

--- a/XKey/UI/SettingsSections/AppearanceSection.swift
+++ b/XKey/UI/SettingsSections/AppearanceSection.swift
@@ -19,7 +19,7 @@ struct AppearanceSection: View {
                             .font(.subheadline)
                             .foregroundColor(.secondary)
                         
-                        HStack(spacing: 12) {
+                        VStack(alignment: .leading, spacing: 10) {
                             ForEach(MenuBarIconStyle.allCases, id: \.self) { style in
                                 SettingsRadioButton(
                                     title: style.displayName,
@@ -30,6 +30,10 @@ struct AppearanceSection: View {
                             }
                         }
                         .padding(.leading, 8)
+
+                        Text("Emoji sẽ hiển thị 🇻🇳 khi ở tiếng Việt và 🇬🇧 khi ở tiếng Anh.")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
                     }
                 }
                 

--- a/XKey/UI/StatusBarManager.swift
+++ b/XKey/UI/StatusBarManager.swift
@@ -177,14 +177,26 @@ class StatusBarManager: ObservableObject {
     private func updateStatusIcon() {
         guard let button = statusItem?.button else { return }
         
-        // Determine icon text based on icon style and Vietnamese mode
-        let iconText: String
         switch menuBarIconStyle {
-        case .x:
-            iconText = viewModel.isVietnameseEnabled ? "X" : "E"
-        case .v:
-            iconText = viewModel.isVietnameseEnabled ? "V" : "E"
+        case .icon:
+            let iconText = viewModel.isVietnameseEnabled ? "🇻🇳" : "🇬🇧"
+            let attributes: [NSAttributedString.Key: Any] = [
+                .font: NSFont.systemFont(ofSize: 16),
+            ]
+
+            button.image = nil
+            button.imagePosition = .noImage
+            button.title = ""
+            button.attributedTitle = NSAttributedString(string: iconText, attributes: attributes)
+            return
+
+        case .x, .v:
+            break
         }
+
+        let iconText = menuBarIconStyle == .x
+            ? (viewModel.isVietnameseEnabled ? "X" : "E")
+            : (viewModel.isVietnameseEnabled ? "V" : "E")
         
         let attributes: [NSAttributedString.Key: Any] = [
             .font: NSFont.systemFont(ofSize: 14, weight: .semibold),
@@ -213,6 +225,9 @@ class StatusBarManager: ObservableObject {
         }
         
         image.isTemplate = true
+        button.attributedTitle = NSAttributedString(string: "")
+        button.title = ""
+        button.imagePosition = .imageOnly
         button.image = image
     }
     


### PR DESCRIPTION
Mình thêm option dùng emoji cho biểu tượng menubar. 

Giao diện setting:

<img width="1884" height="1588" alt="69078" src="https://github.com/user-attachments/assets/907990ba-b3b6-4aa4-bc9e-9f561b416b19" />

Biểu tượng trên thanh menubar:
- mode tiếng Việt

<img width="666" height="74" alt="CleanShot 2026-04-20 at 23 36 06@2x" src="https://github.com/user-attachments/assets/e25ec0cb-dc89-433b-9565-a97257da3e01" />


- mode tiếng Anh

<img width="658" height="78" alt="CleanShot 2026-04-20 at 23 35 22@2x" src="https://github.com/user-attachments/assets/576277a2-a902-4998-800a-4881384bbc62" />
