### PR TITLE
feat(sync): add iCloud settings sync via NSUbiquitousKeyValueStore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ appcast.xml
 .agent/
 .serena/
 .playwright-mcp/
+.codegraph/
+.cursor/

--- a/XKey.xcodeproj/project.pbxproj
+++ b/XKey.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		100D2BE22EF2C59700C26B87 /* VowelSequenceValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000005 /* VowelSequenceValidator.swift */; };
 		100D2BE42EF2C71E00C26B87 /* IMKitHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 100D2BE32EF2C71E00C26B87 /* IMKitHelper.swift */; };
 		100D2BE62EF2C72600C26B87 /* SharedSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 100D2BE52EF2C72600C26B87 /* SharedSettings.swift */; };
+		ICLOUDSYNC001 /* iCloudSyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = ICLOUDSYNC002 /* iCloudSyncManager.swift */; };
 		10133E5C2EF04B0C00BBE6AE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 10133E5B2EF04B0C00BBE6AE /* Assets.xcassets */; };
 		101A44482ED419AE003F9D05 /* Preferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 101A44472ED419AE003F9D05 /* Preferences.swift */; };
 		1025CD6E2F27CA13007B6E9F /* VNEngineBackspaceRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1025CD6D2F27CA13007B6E9F /* VNEngineBackspaceRestoreTests.swift */; };
@@ -110,6 +111,7 @@
 		DEBUGVIEW001 /* DebugView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBUGVIEW002 /* DebugView.swift */; };
 		DEBUGVM001 /* DebugViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBUGVM002 /* DebugViewModel.swift */; };
 		E2BB81375FD0B38574D4F669 /* SharedSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 100D2BE52EF2C72600C26B87 /* SharedSettings.swift */; };
+		ICLOUDSYNC003 /* iCloudSyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = ICLOUDSYNC002 /* iCloudSyncManager.swift */; };
 		E52C23534F4E3183B55BE6D0 /* ExcludedAppsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FB7B1CC880090240CFD79B3 /* ExcludedAppsSection.swift */; };
 		E575FD959786D9DC3A1E6856 /* ConvertToolSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A3D9B46E4A73E69A837ADAD /* ConvertToolSection.swift */; };
 		E93062521966136C34EDEC22 /* VNEngineSmartSwitch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AAC14FFBBB2B10B6A983B1A /* VNEngineSmartSwitch.swift */; };
@@ -122,6 +124,7 @@
 		FC31E5BF03BAE76EB0EF5881 /* CustomConsonantChipEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12D7FA2CC6EE444A4EB7B965 /* CustomConsonantChipEditor.swift */; };
 		FFFF798B22C18C084A0F7458 /* MacroSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F58879C0DDD2958AA9FF0D /* MacroSection.swift */; };
 		L10N00001 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = L10N00002 /* Localizable.xcstrings */; };
+		ICLOUDSYNCTEST001 /* iCloudSyncManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ICLOUDSYNCTEST002 /* iCloudSyncManagerTests.swift */; };
 		LANG0001 /* AppLanguageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = LANG0002 /* AppLanguageTests.swift */; };
 		LAUNCHATLOGIN001 /* LaunchAtLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = LAUNCHATLOGIN002 /* LaunchAtLogin.swift */; };
 		MACR0001 /* MacroManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = MACR0002 /* MacroManagerTests.swift */; };
@@ -158,6 +161,7 @@
 		100D2BDE2EF2C21800C26B87 /* XKeyRelease.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = XKeyRelease.entitlements; sourceTree = "<group>"; };
 		100D2BE32EF2C71E00C26B87 /* IMKitHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IMKitHelper.swift; sourceTree = "<group>"; };
 		100D2BE52EF2C72600C26B87 /* SharedSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedSettings.swift; sourceTree = "<group>"; };
+		ICLOUDSYNC002 /* iCloudSyncManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iCloudSyncManager.swift; sourceTree = "<group>"; };
 		10133E5B2EF04B0C00BBE6AE /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		101A44472ED419AE003F9D05 /* Preferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preferences.swift; sourceTree = "<group>"; };
 		1025CD6D2F27CA13007B6E9F /* VNEngineBackspaceRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VNEngineBackspaceRestoreTests.swift; sourceTree = "<group>"; };
@@ -248,6 +252,7 @@
 		EXCLUDEDAPPS002 /* ExcludedAppsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExcludedAppsView.swift; sourceTree = "<group>"; };
 		F362794B762A19FE8D883F35 /* AdvancedSection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AdvancedSection.swift; sourceTree = "<group>"; };
 		L10N00002 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
+		ICLOUDSYNCTEST002 /* iCloudSyncManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iCloudSyncManagerTests.swift; sourceTree = "<group>"; };
 		LANG0002 /* AppLanguageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLanguageTests.swift; sourceTree = "<group>"; };
 		LAUNCHATLOGIN002 /* LaunchAtLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchAtLogin.swift; sourceTree = "<group>"; };
 		MACR0002 /* MacroManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacroManagerTests.swift; sourceTree = "<group>"; };
@@ -336,6 +341,7 @@
 				1089F7EB2EF76F2300E833ED /* OverlayAppDetector.swift */,
 				10FDCC1B2EF5942400B2D9AC /* InputSourceSwitcher.swift */,
 				100D2BE52EF2C72600C26B87 /* SharedSettings.swift */,
+				ICLOUDSYNC002 /* iCloudSyncManager.swift */,
 				100D2BE32EF2C71E00C26B87 /* IMKitHelper.swift */,
 				LAUNCHATLOGIN002 /* LaunchAtLogin.swift */,
 				APPVERSION002 /* AppVersion.swift */,
@@ -544,6 +550,7 @@
 				2259E2E83868C7ADD9DD4FF3 /* SessionMonitoringTests.swift */,
 				82224BF07EC7A838D6A022DB /* ToggleRulesTests.swift */,
 				LANG0002 /* AppLanguageTests.swift */,
+				ICLOUDSYNCTEST002 /* iCloudSyncManagerTests.swift */,
 				MACR0002 /* MacroManagerTests.swift */,
 			);
 			path = XKeyTests;
@@ -717,6 +724,7 @@
 				100D2BDC2EF2C1D800C26B87 /* InputProcessor.swift in Sources */,
 				100D2BDD2EF2C1D800C26B87 /* VNEngineSettings.swift in Sources */,
 				E2BB81375FD0B38574D4F669 /* SharedSettings.swift in Sources */,
+				ICLOUDSYNC003 /* iCloudSyncManager.swift in Sources */,
 				259D34BEC13552450AB30413 /* DebugLogger.swift in Sources */,
 				F97414DB17E4F78264530EF1 /* KeyCodeToCharacter.swift in Sources */,
 				TYPBUF003 /* TypingBuffer.swift in Sources */,
@@ -780,6 +788,7 @@
 				CONVERTVM001 /* ConvertToolViewModel.swift in Sources */,
 				EXCLUDEDAPPS001 /* ExcludedAppsView.swift in Sources */,
 				100D2BE62EF2C72600C26B87 /* SharedSettings.swift in Sources */,
+				ICLOUDSYNC001 /* iCloudSyncManager.swift in Sources */,
 				F97414DA17E4F78264530EF0 /* KeyCodeToCharacter.swift in Sources */,
 				795D22D182670DD83BDECF21 /* XKey/UI/WindowTitleRulesView.swift in Sources */,
 				10BEC2BC2F2675B200D6A3C3 /* TranslationNetworkManager.swift in Sources */,
@@ -838,6 +847,7 @@
 				64C427CD211649CE8B7DDCE2 /* SessionMonitoringTests.swift in Sources */,
 				8B4B48A67B6088E74942F573 /* ToggleRulesTests.swift in Sources */,
 				LANG0001 /* AppLanguageTests.swift in Sources */,
+				ICLOUDSYNCTEST001 /* iCloudSyncManagerTests.swift in Sources */,
 				MACR0001 /* MacroManagerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/XKey/App/AppDelegate.swift
+++ b/XKey/App/AppDelegate.swift
@@ -252,6 +252,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Setup toggle window title rules hotkey
         setupToggleWindowRulesHotkey()
 
+        // Setup iCloud settings sync
+        iCloudSyncManager.shared.setup()
+
         // Setup Sparkle auto-update
         setupSparkleUpdater()
 

--- a/XKey/Localizable.xcstrings
+++ b/XKey/Localizable.xcstrings
@@ -8625,6 +8625,342 @@
           }
         }
       }
+    },
+    "Đồng bộ thiết lập qua iCloud": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sync settings via iCloud"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通过 iCloud 同步设置"
+          }
+        }
+      }
+    },
+    "Đồng bộ ngay": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sync now"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "立即同步"
+          }
+        }
+      }
+    },
+    "Tự động đồng bộ cài đặt giữa các máy Mac cùng tài khoản iCloud.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatically sync settings between Macs with the same iCloud account."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在使用同一 iCloud 账户的 Mac 之间自动同步设置。"
+          }
+        }
+      }
+    },
+    "Dữ liệu được đồng bộ:": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Data being synced:"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "同步的数据："
+          }
+        }
+      }
+    },
+    "Thiết lập": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置"
+          }
+        }
+      }
+    },
+    "Hotkeys": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hotkeys"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "快捷键"
+          }
+        }
+      }
+    },
+    "Từ điển": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dictionary"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "词典"
+          }
+        }
+      }
+    },
+    "Quy tắc": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rules"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "规则"
+          }
+        }
+      }
+    },
+    "Đã đồng bộ lúc %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Synced at %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已于 %@ 同步"
+          }
+        }
+      }
+    },
+    "Đã đồng bộ": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Synced"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已同步"
+          }
+        }
+      }
+    },
+    "Đang tải lên iCloud...": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uploading to iCloud..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在上传到 iCloud..."
+          }
+        }
+      }
+    },
+    "Đang tải về từ iCloud...": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Downloading from iCloud..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在从 iCloud 下载..."
+          }
+        }
+      }
+    },
+    "Chờ đồng bộ": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Waiting to sync"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "等待同步"
+          }
+        }
+      }
+    },
+    "Dung lượng: %@ / 1 MB": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Size: %@ / 1 MB"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "大小：%@ / 1 MB"
+          }
+        }
+      }
+    },
+    "Không thể đọc thiết lập": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cannot read settings"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法读取设置"
+          }
+        }
+      }
+    },
+    "Vượt giới hạn 1MB iCloud": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iCloud 1MB limit exceeded"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "超过 iCloud 1MB 限制"
+          }
+        }
+      }
+    },
+    "iCloud Sync": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iCloud Sync"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iCloud 同步"
+          }
+        }
+      }
+    },
+    "Export từ iCloud": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export from iCloud"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从 iCloud 导出"
+          }
+        }
+      }
+    },
+    "Không có dữ liệu trên iCloud": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No data on iCloud"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iCloud 上没有数据"
+          }
+        }
+      }
+    },
+    "Lưu thiết lập từ iCloud ra file": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save iCloud settings to file"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将 iCloud 设置保存到文件"
+          }
+        }
+      }
+    },
+    "Đã export thiết lập từ iCloud": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iCloud settings exported successfully"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已成功导出 iCloud 设置"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/XKey/UI/SettingsSections/BackupRestoreSection.swift
+++ b/XKey/UI/SettingsSections/BackupRestoreSection.swift
@@ -16,10 +16,109 @@ struct BackupRestoreSection: View {
     @State private var alertMessage = ""
     @State private var countdownTimer: Timer?
     @State private var restartReason: RestartReason = .importSettings
-    
+    @State private var iCloudSyncEnabled = iCloudSyncManager.shared.isEnabled
+    @State private var syncStatus = iCloudSyncManager.shared.status
+    @State private var lastSyncDate = iCloudSyncManager.shared.lastSyncDate
+    @State private var syncStatusObserver: NSObjectProtocol?
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
+                // iCloud Sync Section
+                SettingsGroup(title: "iCloud Sync") {
+                    VStack(alignment: .leading, spacing: 10) {
+                        Toggle(isOn: $iCloudSyncEnabled) {
+                            HStack(spacing: 6) {
+                                Image(systemName: "icloud")
+                                Text("Đồng bộ thiết lập qua iCloud")
+                            }
+                        }
+                        .onChange(of: iCloudSyncEnabled) { newValue in
+                            iCloudSyncManager.shared.isEnabled = newValue
+                            syncStatus = iCloudSyncManager.shared.status
+                            lastSyncDate = iCloudSyncManager.shared.lastSyncDate
+                        }
+
+                        if iCloudSyncEnabled {
+                            Divider()
+
+                            HStack(spacing: 6) {
+                                iCloudSyncStatusIcon(syncStatus)
+                                iCloudSyncStatusText(syncStatus, lastSyncDate: lastSyncDate)
+                                Spacer()
+                                Button(action: {
+                                    iCloudSyncManager.shared.pushToCloud()
+                                    syncStatus = iCloudSyncManager.shared.status
+                                    lastSyncDate = iCloudSyncManager.shared.lastSyncDate
+                                }) {
+                                    HStack(spacing: 4) {
+                                        Image(systemName: "arrow.triangle.2.circlepath")
+                                        Text("Đồng bộ ngay")
+                                    }
+                                }
+                                .buttonStyle(.bordered)
+                                .controlSize(.small)
+                            }
+
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Dữ liệu được đồng bộ:")
+                                    .font(.caption)
+                                    .fontWeight(.medium)
+                                    .foregroundColor(.secondary)
+
+                                HStack(spacing: 12) {
+                                    iCloudSyncItem(icon: "gearshape", text: "Thiết lập")
+                                    iCloudSyncItem(icon: "keyboard", text: "Hotkeys")
+                                    iCloudSyncItem(icon: "text.badge.plus", text: "Macro")
+                                }
+                                HStack(spacing: 12) {
+                                    iCloudSyncItem(icon: "text.book.closed", text: "Từ điển")
+                                    iCloudSyncItem(icon: "list.bullet", text: "Quy tắc")
+                                    iCloudSyncItem(icon: "globe", text: "Dịch thuật")
+                                }
+                            }
+
+                            HStack {
+                                if let size = iCloudSyncManager.shared.syncDataSizeBytes {
+                                    let sizeStr = ByteCountFormatter.string(fromByteCount: Int64(size), countStyle: .file)
+                                    Text(String(localized: "Dung lượng: \(sizeStr) / 1 MB"))
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                }
+                                Spacer()
+                                Button(action: exportFromiCloud) {
+                                    HStack(spacing: 4) {
+                                        Image(systemName: "square.and.arrow.up.on.square")
+                                        Text("Export từ iCloud")
+                                    }
+                                }
+                                .buttonStyle(.bordered)
+                                .controlSize(.small)
+                                .disabled(iCloudSyncManager.shared.syncDataSizeBytes == nil)
+                            }
+                        } else {
+                            Text("Tự động đồng bộ cài đặt giữa các máy Mac cùng tài khoản iCloud.")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
+                .onAppear {
+                    syncStatusObserver = NotificationCenter.default.addObserver(
+                        forName: .iCloudSyncStatusDidChange,
+                        object: nil,
+                        queue: .main
+                    ) { _ in
+                        syncStatus = iCloudSyncManager.shared.status
+                        lastSyncDate = iCloudSyncManager.shared.lastSyncDate
+                    }
+                }
+                .onDisappear {
+                    if let observer = syncStatusObserver {
+                        NotificationCenter.default.removeObserver(observer)
+                    }
+                }
+
                 // Export Section
                 SettingsGroup(title: "Sao lưu thiết lập") {
                     VStack(alignment: .leading, spacing: 8) {
@@ -204,6 +303,31 @@ struct BackupRestoreSection: View {
         }
     }
     
+    private func exportFromiCloud() {
+        guard let data = iCloudSyncManager.shared.exportCloudData() else {
+            showAlert(title: String(localized: "Lỗi"), message: String(localized: "Không có dữ liệu trên iCloud"))
+            return
+        }
+
+        let panel = NSSavePanel()
+        panel.title = "Export iCloud Settings"
+        panel.message = String(localized: "Lưu thiết lập từ iCloud ra file")
+        let df = DateFormatter()
+        df.dateFormat = "yyyy-MM-dd"
+        panel.nameFieldStringValue = "XKey-iCloud-\(df.string(from: Date())).plist"
+        panel.allowedContentTypes = [.propertyList]
+        panel.canCreateDirectories = true
+
+        if panel.runModal() == .OK, let url = panel.url {
+            do {
+                try data.write(to: url)
+                showAlert(title: String(localized: "Thành công"), message: String(localized: "Đã export thiết lập từ iCloud"))
+            } catch {
+                showAlert(title: String(localized: "Lỗi"), message: String(localized: "Không thể lưu file: \(error.localizedDescription)"))
+            }
+        }
+    }
+
     // MARK: - Reset to Default
     
     private func performReset() {
@@ -278,6 +402,75 @@ struct BackupRestoreSection: View {
         alertTitle = title
         alertMessage = message
         showSuccessAlert = true
+    }
+}
+
+// MARK: - iCloud Sync Helper Views
+
+private func iCloudSyncStatusIcon(_ status: iCloudSyncStatus) -> some View {
+    Group {
+        switch status {
+        case .synced:
+            Image(systemName: "checkmark.icloud")
+                .foregroundColor(.green)
+        case .pushing:
+            Image(systemName: "icloud.and.arrow.up")
+                .foregroundColor(.blue)
+        case .pulling:
+            Image(systemName: "icloud.and.arrow.down")
+                .foregroundColor(.blue)
+        case .error:
+            Image(systemName: "exclamationmark.icloud")
+                .foregroundColor(.orange)
+        default:
+            Image(systemName: "icloud")
+                .foregroundColor(.secondary)
+        }
+    }
+    .font(.caption)
+}
+
+@ViewBuilder
+private func iCloudSyncStatusText(_ status: iCloudSyncStatus, lastSyncDate: Date?) -> some View {
+    switch status {
+    case .synced:
+        if let date = lastSyncDate {
+            let timeStr = date.formatted(date: .abbreviated, time: .shortened)
+            Text(String(localized: "Đã đồng bộ lúc \(timeStr)"))
+                .font(.caption)
+                .foregroundColor(.secondary)
+        } else {
+            Text("Đã đồng bộ")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+    case .pushing:
+        Text("Đang tải lên iCloud...")
+            .font(.caption)
+            .foregroundColor(.blue)
+    case .pulling:
+        Text("Đang tải về từ iCloud...")
+            .font(.caption)
+            .foregroundColor(.blue)
+    case .error(let msg):
+        Text(msg)
+            .font(.caption)
+            .foregroundColor(.orange)
+    default:
+        Text("Chờ đồng bộ")
+            .font(.caption)
+            .foregroundColor(.secondary)
+    }
+}
+
+private func iCloudSyncItem(icon: String, text: String) -> some View {
+    HStack(spacing: 3) {
+        Image(systemName: icon)
+            .font(.system(size: 9))
+            .foregroundColor(.accentColor)
+        Text(text)
+            .font(.caption2)
+            .foregroundColor(.secondary)
     }
 }
 

--- a/XKey/Utilities/SharedSettings.swift
+++ b/XKey/Utilities/SharedSettings.swift
@@ -965,8 +965,36 @@ class SharedSettings {
         )
     }
     
+    // MARK: - iCloud Sync Helpers
+
+    func exportSettingsForSync() -> Data? {
+        let dict = readPlistDict()
+        guard !dict.isEmpty else { return nil }
+        return try? PropertyListSerialization.data(fromPropertyList: dict, format: .binary, options: 0)
+    }
+
+    func importSettingsForSync(from data: Data) {
+        guard let dict = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any] else { return }
+
+        isBatchUpdating = true
+        writePlistDict(dict)
+        isBatchUpdating = false
+
+        if let langRaw = dict[SharedSettingsKey.appLanguage.rawValue] as? String,
+           AppLanguage(rawValue: langRaw) != nil {
+            UserDefaults.standard.set(langRaw, forKey: "appLanguage")
+        }
+
+        notifySettingsChanged()
+        NotificationCenter.default.post(name: .tempOffToolbarSettingsDidChange, object: nil)
+        NotificationCenter.default.post(name: .convertToolHotkeyDidChange, object: nil)
+        NotificationCenter.default.post(name: .translationSettingsDidChange, object: nil)
+        NotificationCenter.default.post(name: .translationToolbarSettingsDidChange, object: nil)
+        NotificationCenter.default.post(name: .debugSettingsDidChange, object: nil)
+    }
+
     // MARK: - Export/Import Settings
-    
+
     /// Export all settings to a plist file
     /// - Returns: The exported plist data (XML format for human readability), or nil if export failed
     func exportSettings() -> Data? {

--- a/XKey/Utilities/iCloudSyncManager.swift
+++ b/XKey/Utilities/iCloudSyncManager.swift
@@ -1,0 +1,217 @@
+//
+//  iCloudSyncManager.swift
+//  XKey
+//
+//  Syncs settings to/from iCloud via NSUbiquitousKeyValueStore
+//
+
+import Foundation
+
+enum iCloudSyncStatus: Equatable {
+    case disabled
+    case idle
+    case pushing
+    case pulling
+    case synced
+    case error(String)
+}
+
+protocol KeyValueStoreProtocol: AnyObject {
+    func data(forKey key: String) -> Data?
+    func setData(_ data: Data?, forKey key: String)
+    @discardableResult func synchronize() -> Bool
+}
+
+extension NSUbiquitousKeyValueStore: KeyValueStoreProtocol {
+    func setData(_ data: Data?, forKey key: String) {
+        set(data, forKey: key)
+    }
+}
+
+class iCloudSyncManager {
+
+    static let shared = iCloudSyncManager()
+
+    private let kvStore: KeyValueStoreProtocol
+    private let syncKey = "XKey.syncedSettings"
+    private var pushTimer: Timer?
+    private var isPulling = false
+    private var isObserving = false
+
+    private let enabledKey = "XKey.iCloudSyncEnabled"
+
+    private(set) var status: iCloudSyncStatus = .disabled
+
+    var isEnabled: Bool {
+        get { UserDefaults.standard.bool(forKey: enabledKey) }
+        set {
+            let wasEnabled = isEnabled
+            UserDefaults.standard.set(newValue, forKey: enabledKey)
+            if newValue && !wasEnabled {
+                status = .idle
+                startObserving()
+                pushToCloud()
+            } else if !newValue && wasEnabled {
+                stopObserving()
+                status = .disabled
+                notifyStatusChanged()
+            }
+        }
+    }
+
+    var lastSyncDate: Date? {
+        UserDefaults.standard.object(forKey: "XKey.lastCloudSyncDate") as? Date
+    }
+
+    var syncDataSizeBytes: Int? {
+        kvStore.data(forKey: syncKey)?.count
+    }
+
+    private init() {
+        self.kvStore = NSUbiquitousKeyValueStore.default
+    }
+
+    init(store: KeyValueStoreProtocol) {
+        self.kvStore = store
+    }
+
+    func setup() {
+        guard isEnabled else {
+            status = .disabled
+            return
+        }
+        status = .idle
+        startObserving()
+        kvStore.synchronize()
+    }
+
+    private func startObserving() {
+        guard !isObserving else { return }
+        isObserving = true
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(kvStoreDidChange(_:)),
+            name: NSUbiquitousKeyValueStore.didChangeExternallyNotification,
+            object: nil
+        )
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(localSettingsDidChange),
+            name: .sharedSettingsDidChange,
+            object: nil
+        )
+    }
+
+    private func stopObserving() {
+        guard isObserving else { return }
+        isObserving = false
+
+        NotificationCenter.default.removeObserver(
+            self,
+            name: NSUbiquitousKeyValueStore.didChangeExternallyNotification,
+            object: nil
+        )
+        NotificationCenter.default.removeObserver(
+            self,
+            name: .sharedSettingsDidChange,
+            object: nil
+        )
+        pushTimer?.invalidate()
+        pushTimer = nil
+    }
+
+    @objc private func localSettingsDidChange() {
+        schedulePush()
+    }
+
+    private func schedulePush() {
+        guard isEnabled, !isPulling else { return }
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.pushTimer?.invalidate()
+            self.pushTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: false) { [weak self] _ in
+                self?.pushToCloud()
+            }
+        }
+    }
+
+    func pushToCloud() {
+        guard isEnabled, !isPulling else { return }
+        guard let data = SharedSettings.shared.exportSettingsForSync() else {
+            status = .error(String(localized: "Không thể đọc thiết lập"))
+            notifyStatusChanged()
+            return
+        }
+        status = .pushing
+        notifyStatusChanged()
+        kvStore.setData(data, forKey: syncKey)
+        kvStore.synchronize()
+        UserDefaults.standard.set(Date(), forKey: "XKey.lastCloudSyncDate")
+        status = .synced
+        sharedLogSuccess("Settings pushed to iCloud (\(data.count) bytes)")
+        notifyStatusChanged()
+    }
+
+    @objc private func kvStoreDidChange(_ notification: Notification) {
+        guard isEnabled else { return }
+
+        guard let userInfo = notification.userInfo,
+              let reason = userInfo[NSUbiquitousKeyValueStoreChangeReasonKey] as? Int,
+              let changedKeys = userInfo[NSUbiquitousKeyValueStoreChangedKeysKey] as? [String] else { return }
+
+        guard changedKeys.contains(syncKey) else { return }
+
+        switch reason {
+        case NSUbiquitousKeyValueStoreServerChange,
+             NSUbiquitousKeyValueStoreInitialSyncChange:
+            pullFromCloud()
+        case NSUbiquitousKeyValueStoreQuotaViolationChange:
+            status = .error(String(localized: "Vượt giới hạn 1MB iCloud"))
+            sharedLogWarning("iCloud KVS quota exceeded — sync paused")
+            notifyStatusChanged()
+        default:
+            break
+        }
+    }
+
+    func pullFromCloud() {
+        guard let data = kvStore.data(forKey: syncKey) else { return }
+
+        let apply = { [weak self] in
+            guard let self = self else { return }
+            self.isPulling = true
+            self.status = .pulling
+            self.notifyStatusChanged()
+            SharedSettings.shared.importSettingsForSync(from: data)
+            self.isPulling = false
+            UserDefaults.standard.set(Date(), forKey: "XKey.lastCloudSyncDate")
+            self.status = .synced
+            sharedLogSuccess("Settings pulled from iCloud (\(data.count) bytes)")
+            self.notifyStatusChanged()
+        }
+
+        if Thread.isMainThread {
+            apply()
+        } else {
+            DispatchQueue.main.async(execute: apply)
+        }
+    }
+
+    func exportCloudData() -> Data? {
+        guard let binary = kvStore.data(forKey: syncKey),
+              let dict = try? PropertyListSerialization.propertyList(from: binary, format: nil) as? [String: Any] else {
+            return nil
+        }
+        return try? PropertyListSerialization.data(fromPropertyList: dict, format: .xml, options: 0)
+    }
+
+    private func notifyStatusChanged() {
+        NotificationCenter.default.post(name: .iCloudSyncStatusDidChange, object: nil)
+    }
+}
+
+extension Notification.Name {
+    static let iCloudSyncStatusDidChange = Notification.Name("XKey.iCloudSyncStatusDidChange")
+}

--- a/XKey/XKey.entitlements
+++ b/XKey/XKey.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
+	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
 	<key>com.apple.security.app-sandbox</key>
 	<false/>
 	<key>com.apple.security.application-groups</key>

--- a/XKey/XKeyRelease.entitlements
+++ b/XKey/XKeyRelease.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
+	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>7E6Z9B4F2H.com.codetay.inputmethod.XKey</string>

--- a/XKeyTests/iCloudSyncManagerTests.swift
+++ b/XKeyTests/iCloudSyncManagerTests.swift
@@ -1,0 +1,177 @@
+//
+//  iCloudSyncManagerTests.swift
+//  XKeyTests
+//
+
+import XCTest
+@testable import XKey
+
+class MockKeyValueStore: KeyValueStoreProtocol {
+    private var storage: [String: Data] = [:]
+
+    func data(forKey key: String) -> Data? { storage[key] }
+
+    func setData(_ data: Data?, forKey key: String) {
+        storage[key] = data
+    }
+
+    @discardableResult func synchronize() -> Bool { true }
+}
+
+class iCloudSyncManagerTests: XCTestCase {
+
+    private var mockStore: MockKeyValueStore!
+    private var sut: iCloudSyncManager!
+
+    override func setUp() {
+        super.setUp()
+        mockStore = MockKeyValueStore()
+        sut = iCloudSyncManager(store: mockStore)
+        UserDefaults.standard.removeObject(forKey: "XKey.iCloudSyncEnabled")
+        UserDefaults.standard.removeObject(forKey: "XKey.lastCloudSyncDate")
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: "XKey.iCloudSyncEnabled")
+        UserDefaults.standard.removeObject(forKey: "XKey.lastCloudSyncDate")
+        sut = nil
+        mockStore = nil
+        super.tearDown()
+    }
+
+    // MARK: - Initial State
+
+    func testInitialStatusIsDisabled() {
+        XCTAssertEqual(sut.status, .disabled)
+    }
+
+    func testIsEnabledDefaultsFalse() {
+        XCTAssertFalse(sut.isEnabled)
+    }
+
+    func testLastSyncDateDefaultsNil() {
+        XCTAssertNil(sut.lastSyncDate)
+    }
+
+    // MARK: - Enable / Disable
+
+    func testEnableSetsStatusToSyncedAfterPush() {
+        sut.isEnabled = true
+        XCTAssertEqual(sut.status, .synced)
+        XCTAssertTrue(UserDefaults.standard.bool(forKey: "XKey.iCloudSyncEnabled"))
+    }
+
+    func testDisableSetsStatusToDisabled() {
+        sut.isEnabled = true
+        sut.isEnabled = false
+        XCTAssertEqual(sut.status, .disabled)
+    }
+
+    func testEnableWritesDataToStore() {
+        sut.isEnabled = true
+        let data = mockStore.data(forKey: "XKey.syncedSettings")
+        XCTAssertNotNil(data, "Enabling sync should push settings data to the store")
+    }
+
+    // MARK: - Push
+
+    func testPushToCloudUpdatesLastSyncDate() {
+        sut.isEnabled = true
+        sut.pushToCloud()
+        XCTAssertNotNil(sut.lastSyncDate)
+    }
+
+    func testPushToCloudSetsStatusSynced() {
+        sut.isEnabled = true
+        sut.pushToCloud()
+        XCTAssertEqual(sut.status, .synced)
+    }
+
+    func testPushDoesNothingWhenDisabled() {
+        sut.pushToCloud()
+        XCTAssertEqual(sut.status, .disabled)
+        XCTAssertNil(mockStore.data(forKey: "XKey.syncedSettings"))
+    }
+
+    // MARK: - Pull
+
+    func testPullFromCloudImportsSettings() {
+        sut.isEnabled = true
+        sut.pushToCloud()
+
+        sut.pullFromCloud()
+
+        let exp = expectation(description: "main queue drain")
+        DispatchQueue.main.async { exp.fulfill() }
+        wait(for: [exp], timeout: 1.0)
+
+        XCTAssertEqual(sut.status, .synced)
+    }
+
+    func testPullUpdatesLastSyncDate() {
+        sut.isEnabled = true
+        sut.pushToCloud()
+        let beforePull = sut.lastSyncDate
+
+        Thread.sleep(forTimeInterval: 0.01)
+        sut.pullFromCloud()
+
+        let exp = expectation(description: "main queue drain")
+        DispatchQueue.main.async { exp.fulfill() }
+        wait(for: [exp], timeout: 1.0)
+
+        XCTAssertNotNil(sut.lastSyncDate)
+        if let before = beforePull, let after = sut.lastSyncDate {
+            XCTAssertGreaterThanOrEqual(after, before)
+        }
+    }
+
+    // MARK: - Data Size
+
+    func testSyncDataSizeBytesReturnsNilWhenEmpty() {
+        XCTAssertNil(sut.syncDataSizeBytes)
+    }
+
+    func testSyncDataSizeBytesReturnsValueAfterPush() {
+        sut.isEnabled = true
+        sut.pushToCloud()
+        XCTAssertNotNil(sut.syncDataSizeBytes)
+        XCTAssertGreaterThan(sut.syncDataSizeBytes ?? 0, 0)
+    }
+
+    // MARK: - Setup
+
+    func testSetupWhenDisabledStaysDisabled() {
+        sut.setup()
+        XCTAssertEqual(sut.status, .disabled)
+    }
+
+    func testSetupWhenEnabledSetsIdle() {
+        UserDefaults.standard.set(true, forKey: "XKey.iCloudSyncEnabled")
+        sut.setup()
+        XCTAssertEqual(sut.status, .idle)
+    }
+
+    // MARK: - Round-trip
+
+    func testRoundTripDataIsValidPlist() {
+        sut.isEnabled = true
+        sut.pushToCloud()
+
+        let data = mockStore.data(forKey: "XKey.syncedSettings")
+        XCTAssertNotNil(data)
+
+        if let data = data {
+            let dict = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any]
+            XCTAssertNotNil(dict, "Pushed data should be a valid plist dictionary")
+        }
+    }
+
+    // MARK: - Double Enable
+
+    func testDoubleEnableDoesNotCrash() {
+        sut.isEnabled = true
+        sut.isEnabled = true
+        XCTAssertEqual(sut.status, .synced)
+    }
+}


### PR DESCRIPTION
## Summary

  - Sync all XKey settings across Macs via iCloud Key-Value Store (1MB limit)
  - Auto-push on settings change (2s debounce), auto-pull on remote change
  - UI: toggle, live sync status, "Sync now" button, "Export from iCloud" in Backup tab
  - `KeyValueStoreProtocol` abstraction enables mock testing without iCloud
  - 17 unit tests with `MockKeyValueStore`
  - Full vi/en/zh-Hans localization
  - Export from iCloud can reimport using existing import function.
  
<img width="743" height="589" alt="image" src="https://github.com/user-attachments/assets/6dcc43b1-2d20-4685-ab26-10012bf5a96a" />


  ## What gets synced

  All settings, hotkeys, macros, user dictionary, window title rules, excluded apps, and translation config
   — the entire shared plist.

  ## Key design decisions

  - **NSUbiquitousKeyValueStore** over CloudKit — simpler, no login needed, sufficient for settings data
  (<1MB)
  - **Debounced push** (2s) prevents hammering KVS during rapid setting changes
  - **`isPulling` flag** breaks the sync loop (pull → notify → push → ...)
  - **`isObserving` flag** prevents duplicate NotificationCenter observers
  - **`iCloudSyncEnabled` stored in local UserDefaults** — not synced to avoid circular dependency

  ## Test plan

  - [x] Build from Xcode with code signing → enable iCloud Sync → change a setting → verify status shows
  "Synced"
  - [ x] "Export from iCloud" → import the .plist on another machine via Restore
  - [x] Toggle off → verify sync stops
  - [ x] `xcodebuild test -only-testing:XKeyTests/iCloudSyncManagerTests` → 17/17 pass
