### PR TITLE
Sửa lỗi Cmd+, mở cửa sổ cài đặt trống

### DIFF
--- a/XKey/App/XKeyApp.swift
+++ b/XKey/App/XKeyApp.swift
@@ -21,6 +21,14 @@ struct XKeyApp: App {
         Settings {
             EmptyView()
         }
+        .commands {
+            CommandGroup(replacing: .appSettings) {
+                Button("Bảng điều khiển...") {
+                    AppDelegate.shared?.openPreferences()
+                }
+                .keyboardShortcut(",", modifiers: .command)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Tóm tắt

Sửa lỗi phím tắt `Cmd + ,` mở cửa sổ `Cài đặt XKey` trống.

Hiện tại, khi bấm `Bảng điều khiển...` từ menu bar, XKey mở đúng giao diện cài đặt thông qua `AppDelegate.openPreferences()`. Nhưng khi dùng `Cmd + ,`, SwiftUI mở scene `Settings { EmptyView() }`, dẫn tới một cửa sổ trắng không có nội dung.

Thay đổi này override command Settings mặc định của SwiftUI để `Cmd + ,` gọi cùng luồng với menu `Bảng điều khiển...`.

## Thay đổi

- Thêm `.commands` vào `XKeyApp`.
- Thay thế `.appSettings` command mặc định.
- Gắn `Cmd + ,` vào `AppDelegate.shared?.openPreferences()`.

## Kiểm thử

Đã kiểm thử local bằng bản tự biên dịch:

- `Bảng điều khiển...` từ menu bar vẫn mở đúng giao diện cài đặt.
- `Cmd + ,` mở cùng giao diện cài đặt, không còn cửa sổ trắng.
- XKey vẫn gõ tiếng Việt sau khi cấp lại quyền `Accessibility` và `Input Monitoring` cho bản tự biên dịch.

## Ghi chú

Bản local tự biên dịch là ad-hoc signing nên macOS cần cấp lại quyền bảo mật. Thay đổi source không ảnh hưởng đến bản release được ký chính thức.
