### PR TITLE
feat: adaptive input method (Telex + VNI auto-accept)

### DIFF
--- a/XKey.xcodeproj/project.pbxproj
+++ b/XKey.xcodeproj/project.pbxproj
@@ -139,6 +139,7 @@
 		TEST00023 /* TranslationProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = TEST00024 /* TranslationProviderTests.swift */; };
 		TEST00025 /* AXDirectFallbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = TEST00026 /* AXDirectFallbackTests.swift */; };
 		TEST00027 /* VNEngineAutoCapitalizeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = TEST00028 /* VNEngineAutoCapitalizeTests.swift */; };
+		ADAPT0001 /* VNEngineAdaptiveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADAPT0002 /* VNEngineAdaptiveTests.swift */; };
 		TOMBSTONE001 /* SyncTombstoneStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = TOMBSTONE002 /* SyncTombstoneStore.swift */; };
 		TOMBSTONE003 /* SyncTombstoneStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = TOMBSTONE002 /* SyncTombstoneStore.swift */; };
 		TRANSLATTB001 /* TranslationToolbarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = TRANSLATTB002 /* TranslationToolbarController.swift */; };
@@ -271,6 +272,7 @@
 		TEST00024 /* TranslationProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationProviderTests.swift; sourceTree = "<group>"; };
 		TEST00026 /* AXDirectFallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AXDirectFallbackTests.swift; sourceTree = "<group>"; };
 		TEST00028 /* VNEngineAutoCapitalizeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VNEngineAutoCapitalizeTests.swift; sourceTree = "<group>"; };
+		ADAPT0002 /* VNEngineAdaptiveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VNEngineAdaptiveTests.swift; sourceTree = "<group>"; };
 		TOMBSTONE002 /* SyncTombstoneStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncTombstoneStore.swift; sourceTree = "<group>"; };
 		TRANSLATTB002 /* TranslationToolbarController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TranslationToolbarController.swift; sourceTree = "<group>"; };
 		TRANSLATTB004 /* TranslationToolbarView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TranslationToolbarView.swift; sourceTree = "<group>"; };
@@ -560,6 +562,7 @@
 				LANG0002 /* AppLanguageTests.swift */,
 				ICLOUDSYNCTEST002 /* iCloudSyncManagerTests.swift */,
 				MACR0002 /* MacroManagerTests.swift */,
+				ADAPT0002 /* VNEngineAdaptiveTests.swift */,
 			);
 			path = XKeyTests;
 			sourceTree = "<group>";
@@ -861,6 +864,7 @@
 				LANG0001 /* AppLanguageTests.swift in Sources */,
 				ICLOUDSYNCTEST001 /* iCloudSyncManagerTests.swift in Sources */,
 				MACR0001 /* MacroManagerTests.swift in Sources */,
+				ADAPT0001 /* VNEngineAdaptiveTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XKey/Core/Engine/InputProcessor.swift
+++ b/XKey/Core/Engine/InputProcessor.swift
@@ -43,6 +43,8 @@ class InputProcessor {
             return processVNIKey(lowerChar, isUppercase: isUppercase)
         case .simpleTelex1, .simpleTelex2:
             return processSimpleTelexKey(lowerChar, isUppercase: isUppercase)
+        case .adaptive:
+            return processTelexKey(lowerChar, isUppercase: isUppercase)
         }
     }
     
@@ -174,6 +176,9 @@ class InputProcessor {
             return ["s", "f", "r", "x", "j"].contains(char.lowercased().first ?? char)
         case .vni:
             return ["1", "2", "3", "4", "5"].contains(char)
+        case .adaptive:
+            return ["s", "f", "r", "x", "j"].contains(char.lowercased().first ?? char)
+                || ["1", "2", "3", "4", "5"].contains(char)
         }
     }
     
@@ -183,6 +188,9 @@ class InputProcessor {
             return char.lowercased().first == "w" || char == "^"
         case .vni:
             return ["6", "7", "8", "9"].contains(char)
+        case .adaptive:
+            return char.lowercased().first == "w" || char == "^"
+                || ["6", "7", "8", "9"].contains(char)
         }
     }
     

--- a/XKey/Core/Engine/VNEngine.swift
+++ b/XKey/Core/Engine/VNEngine.swift
@@ -1286,14 +1286,14 @@ class VNEngine {
             return true
         }
         
-        // Numbers: only in VNI mode (0-9 are tone marks)
+        // Numbers: tone marks in VNI mode and Adaptive mode (0-9)
         if character.isNumber {
-            return inputMethod == .vni
+            return inputMethod == .vni || inputMethod == .adaptive
         }
-        
-        // Bracket keys: only in Telex mode ([ → ơ, ] → ư)
+
+        // Bracket keys: ơ/ư in Telex mode and Adaptive mode ([ → ơ, ] → ư)
         if character == "[" || character == "]" {
-            return inputMethod == .telex
+            return inputMethod == .telex || inputMethod == .adaptive
         }
         
         // Other characters are not Vietnamese special keys
@@ -1324,9 +1324,10 @@ class VNEngine {
             return true
         }
         
-        // Bracket keys: word break in all modes EXCEPT Telex
+        // Bracket keys: word break in all modes EXCEPT Telex and Adaptive
+        // (in those modes they produce ơ and ư).
         if character == "[" || character == "]" {
-            return inputMethod != .telex
+            return inputMethod != .telex && inputMethod != .adaptive
         }
         
         return false

--- a/XKey/Core/Engine/VNEngine.swift
+++ b/XKey/Core/Engine/VNEngine.swift
@@ -55,6 +55,7 @@ class VNEngine {
     
     var vLanguage = 1              // 0: English, 1: Vietnamese
     var vInputType = 0             // 0: Telex, 1: VNI
+    var vAdaptiveEnabled = false   // Adaptive: accept BOTH Telex & VNI keys, decided per keystroke
     var vCodeTable = 0             // 0: Unicode, 1: TCVN3, 2: VNI-Windows
     var vCheckSpelling = 1         // 0: No, 1: Yes
     var vUseModernOrthography = 1  // 0: òa/úy, 1: oà/uý

--- a/XKey/Core/Engine/VNEngine.swift
+++ b/XKey/Core/Engine/VNEngine.swift
@@ -1280,6 +1280,7 @@ class VNEngine {
     /// - VNI: 0-9
     /// - Simple Telex 1: w, a, e, o, s, f, r, x, j, z, d (NO [ ])
     /// - Simple Telex 2: w, a, e, o, s, f, r, x, j, z, d (NO [ ])
+    /// - Adaptive: Telex keys ∪ VNI keys (letters s/f/r/x/j/w/z, [, ], double letters, and 0-9)
     static func isVietnameseSpecialKey(character: Character, inputMethod: InputMethod) -> Bool {
         // Letters are always processed (Vietnamese engine handles them)
         if character.isLetter {
@@ -1307,7 +1308,7 @@ class VNEngine {
     ///   - inputMethod: The current input method
     /// - Returns: true if this character is a word break
     ///
-    /// Note: In Telex mode, [ and ] are NOT word breaks (they produce ơ and ư)
+    /// Note: In Telex and Adaptive modes, [ and ] are NOT word breaks (they produce ơ and ư)
     static func isWordBreak(character: Character, inputMethod: InputMethod) -> Bool {
         // Whitespace and common punctuation
         let baseWordBreaks: Set<Character> = [

--- a/XKey/Core/Engine/VNEngine.swift
+++ b/XKey/Core/Engine/VNEngine.swift
@@ -245,6 +245,15 @@ class VNEngine {
         
         let isCaps = isUppercase
 
+        // Adaptive input method: choose the effective input type for THIS keystroke
+        // (boundary translation). Digits route to VNI logic; every other key routes
+        // to Telex. Telex/VNI trigger keys are disjoint, so each keystroke maps to
+        // exactly one method. Downstream code keeps reading a concrete vInputType
+        // (0/1) and never sees the adaptive sentinel (4).
+        if vAdaptiveEnabled {
+            vInputType = vietnameseData.isNumberKey(keyCode) ? 1 : 0
+        }
+
         // Check if number key with shift or has other modifier
         if (vietnameseData.isNumberKey(keyCode) && isUppercase) || hasOtherModifier || isWordBreak(keyCode: keyCode) {
             handleWordBreak(keyCode: keyCode, character: character, isCaps: isCaps)

--- a/XKey/Core/Engine/VNEngineSettings.swift
+++ b/XKey/Core/Engine/VNEngineSettings.swift
@@ -48,7 +48,10 @@ extension VNEngine {
             vInputType = 2
         case .simpleTelex2:
             vInputType = 3
+        case .adaptive:
+            vInputType = 0   // base type; per-keystroke effectiveType overrides (boundary translation)
         }
+        vAdaptiveEnabled = (settings.inputMethod == .adaptive)
         
         // Map CodeTable to vCodeTable
         vCodeTable = settings.codeTable.rawValue
@@ -88,17 +91,21 @@ extension VNEngine {
         var settings = EngineSettings()
         
         // Map vInputType to InputMethod
-        switch vInputType {
-        case 0:
-            settings.inputMethod = .telex
-        case 1:
-            settings.inputMethod = .vni
-        case 2:
-            settings.inputMethod = .simpleTelex1
-        case 3:
-            settings.inputMethod = .simpleTelex2
-        default:
-            settings.inputMethod = .telex
+        if vAdaptiveEnabled {
+            settings.inputMethod = .adaptive
+        } else {
+            switch vInputType {
+            case 0:
+                settings.inputMethod = .telex
+            case 1:
+                settings.inputMethod = .vni
+            case 2:
+                settings.inputMethod = .simpleTelex1
+            case 3:
+                settings.inputMethod = .simpleTelex2
+            default:
+                settings.inputMethod = .telex
+            }
         }
         
         // Map vCodeTable to CodeTable

--- a/XKey/Core/Models/VNCharacter.swift
+++ b/XKey/Core/Models/VNCharacter.swift
@@ -442,6 +442,7 @@ enum InputMethod: Int, CaseIterable, Codable {
     case vni = 1
     case simpleTelex1 = 2
     case simpleTelex2 = 3
+    case adaptive = 4
 
     var displayName: String {
         switch self {
@@ -449,6 +450,7 @@ enum InputMethod: Int, CaseIterable, Codable {
         case .vni: return "VNI"
         case .simpleTelex1: return "Simple Telex 1 (w->w, []→[])"
         case .simpleTelex2: return "Simple Telex 2 (w→ư, []→[])"
+        case .adaptive: return "Tự động (Telex + VNI)"
         }
     }
 }

--- a/XKey/Core/Models/VNCharacter.swift
+++ b/XKey/Core/Models/VNCharacter.swift
@@ -438,19 +438,22 @@ enum CodeTable: Int, CaseIterable, Codable {
 // MARK: - Input Methods
 
 enum InputMethod: Int, CaseIterable, Codable {
+    // NOTE: `allCases` follows declaration order, so `.adaptive` is listed first
+    // to appear at the top of the input-method pickers. Raw values are kept stable
+    // (adaptive = 4) for Codable persistence — do not renumber.
+    case adaptive = 4
     case telex = 0
     case vni = 1
     case simpleTelex1 = 2
     case simpleTelex2 = 3
-    case adaptive = 4
 
     var displayName: String {
         switch self {
+        case .adaptive: return "Tự nhận kiểu gõ (Telex + VNI)"
         case .telex: return "Telex (w→ư, []→ơư)"
         case .vni: return "VNI"
         case .simpleTelex1: return "Simple Telex 1 (w->w, []→[])"
         case .simpleTelex2: return "Simple Telex 2 (w→ư, []→[])"
-        case .adaptive: return "Tự động (Telex + VNI)"
         }
     }
 }

--- a/XKey/Localizable.xcstrings
+++ b/XKey/Localizable.xcstrings
@@ -7123,6 +7123,22 @@
         }
       }
     },
+    "Tự nhận kiểu gõ (Telex + VNI)": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adaptive Input (Telex + VNI)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自适应输入 (Telex + VNI)"
+          }
+        }
+      }
+    },
     "Verbose": {
       "localizations": {
         "en": {

--- a/XKeyTests/VNEngineAdaptiveTests.swift
+++ b/XKeyTests/VNEngineAdaptiveTests.swift
@@ -52,4 +52,45 @@ class VNEngineAdaptiveTests: XCTestCase {
         XCTAssertEqual(engine.vInputType, 1)
         XCTAssertEqual(engine.settings.inputMethod, .vni)
     }
+
+    // MARK: - Task 2: dual-typing produces the same Vietnamese output
+
+    /// Helper: type a sequence of (character, keyCode) in adaptive mode and return the word.
+    private func typeAdaptive(_ keys: [(Character, UInt16)]) -> String {
+        engine.reset()
+        engine.vAdaptiveEnabled = true
+        engine.vInputType = 0
+        for (ch, code) in keys {
+            _ = engine.processKey(character: ch, keyCode: code, isUppercase: false)
+        }
+        return engine.getCurrentWord()
+    }
+
+    func testAdaptive_AcuteTone_BothWays() {
+        // Telex: a + s  →  á
+        XCTAssertEqual(typeAdaptive([("a", VietnameseData.KEY_A), ("s", VietnameseData.KEY_S)]), "á")
+        // VNI: a + 1  →  á
+        XCTAssertEqual(typeAdaptive([("a", VietnameseData.KEY_A), ("1", VietnameseData.KEY_1)]), "á")
+    }
+
+    func testAdaptive_Circumflex_BothWays() {
+        // Telex: a + a  →  â
+        XCTAssertEqual(typeAdaptive([("a", VietnameseData.KEY_A), ("a", VietnameseData.KEY_A)]), "â")
+        // VNI: a + 6  →  â
+        XCTAssertEqual(typeAdaptive([("a", VietnameseData.KEY_A), ("6", VietnameseData.KEY_6)]), "â")
+    }
+
+    func testAdaptive_Horn_U_BothWays() {
+        // Telex: u + w  →  ư
+        XCTAssertEqual(typeAdaptive([("u", VietnameseData.KEY_U), ("w", VietnameseData.KEY_W)]), "ư")
+        // VNI: u + 7  →  ư
+        XCTAssertEqual(typeAdaptive([("u", VietnameseData.KEY_U), ("7", VietnameseData.KEY_7)]), "ư")
+    }
+
+    func testAdaptive_Dee_BothWays() {
+        // Telex: d + d  →  đ
+        XCTAssertEqual(typeAdaptive([("d", VietnameseData.KEY_D), ("d", VietnameseData.KEY_D)]), "đ")
+        // VNI: d + 9  →  đ
+        XCTAssertEqual(typeAdaptive([("d", VietnameseData.KEY_D), ("9", VietnameseData.KEY_9)]), "đ")
+    }
 }

--- a/XKeyTests/VNEngineAdaptiveTests.swift
+++ b/XKeyTests/VNEngineAdaptiveTests.swift
@@ -140,4 +140,61 @@ class VNEngineAdaptiveTests: XCTestCase {
             ("v", VietnameseData.KEY_V), ("i", VietnameseData.KEY_I), ("1", VietnameseData.KEY_1)
         ]), "ví")
     }
+
+    // MARK: - Task 5: full equivalence matrix + commit/backspace
+
+    func testAdaptive_EquivalenceMatrix() {
+        // (expected, telexKeys, vniKeys) — each pair must produce `expected` in adaptive mode.
+        let cases: [(String, [(Character, UInt16)], [(Character, UInt16)])] = [
+            ("á", [("a", VietnameseData.KEY_A), ("s", VietnameseData.KEY_S)],
+                  [("a", VietnameseData.KEY_A), ("1", VietnameseData.KEY_1)]),
+            ("à", [("a", VietnameseData.KEY_A), ("f", VietnameseData.KEY_F)],
+                  [("a", VietnameseData.KEY_A), ("2", VietnameseData.KEY_2)]),
+            ("â", [("a", VietnameseData.KEY_A), ("a", VietnameseData.KEY_A)],
+                  [("a", VietnameseData.KEY_A), ("6", VietnameseData.KEY_6)]),
+            ("ê", [("e", VietnameseData.KEY_E), ("e", VietnameseData.KEY_E)],
+                  [("e", VietnameseData.KEY_E), ("6", VietnameseData.KEY_6)]),
+            ("ô", [("o", VietnameseData.KEY_O), ("o", VietnameseData.KEY_O)],
+                  [("o", VietnameseData.KEY_O), ("6", VietnameseData.KEY_6)]),
+            ("ơ", [("o", VietnameseData.KEY_O), ("w", VietnameseData.KEY_W)],
+                  [("o", VietnameseData.KEY_O), ("7", VietnameseData.KEY_7)]),
+            ("ư", [("u", VietnameseData.KEY_U), ("w", VietnameseData.KEY_W)],
+                  [("u", VietnameseData.KEY_U), ("7", VietnameseData.KEY_7)]),
+            ("ă", [("a", VietnameseData.KEY_A), ("w", VietnameseData.KEY_W)],
+                  [("a", VietnameseData.KEY_A), ("8", VietnameseData.KEY_8)]),
+            ("đ", [("d", VietnameseData.KEY_D), ("d", VietnameseData.KEY_D)],
+                  [("d", VietnameseData.KEY_D), ("9", VietnameseData.KEY_9)]),
+        ]
+        for (expected, telex, vni) in cases {
+            XCTAssertEqual(typeAdaptive(telex), expected, "Telex path for \(expected)")
+            XCTAssertEqual(typeAdaptive(vni), expected, "VNI path for \(expected)")
+        }
+    }
+
+    func testAdaptive_WordBreakCommitsThenNewWord() {
+        engine.reset()
+        engine.vAdaptiveEnabled = true
+        engine.vInputType = 0
+        // Type "á" via VNI, commit with space, then start a fresh word via Telex.
+        _ = engine.processKey(character: "a", keyCode: VietnameseData.KEY_A, isUppercase: false)
+        _ = engine.processKey(character: "1", keyCode: VietnameseData.KEY_1, isUppercase: false)
+        XCTAssertEqual(engine.getCurrentWord(), "á")
+        _ = engine.processWordBreak(character: " ")
+        // New word "ô" via Telex
+        _ = engine.processKey(character: "o", keyCode: VietnameseData.KEY_O, isUppercase: false)
+        _ = engine.processKey(character: "o", keyCode: VietnameseData.KEY_O, isUppercase: false)
+        XCTAssertEqual(engine.getCurrentWord(), "ô")
+    }
+
+    func testAdaptive_BackspaceRevertsTone() {
+        engine.reset()
+        engine.vAdaptiveEnabled = true
+        engine.vInputType = 0
+        // "á" via VNI a+1, then backspace removes the tone-bearing char.
+        _ = engine.processKey(character: "a", keyCode: VietnameseData.KEY_A, isUppercase: false)
+        _ = engine.processKey(character: "1", keyCode: VietnameseData.KEY_1, isUppercase: false)
+        XCTAssertEqual(engine.getCurrentWord(), "á")
+        _ = engine.processBackspace()
+        XCTAssertEqual(engine.getCurrentWord(), "", "backspace should clear the single composed char")
+    }
 }

--- a/XKeyTests/VNEngineAdaptiveTests.swift
+++ b/XKeyTests/VNEngineAdaptiveTests.swift
@@ -197,4 +197,53 @@ class VNEngineAdaptiveTests: XCTestCase {
         _ = engine.processBackspace()
         XCTAssertEqual(engine.getCurrentWord(), "", "backspace should clear the single composed char")
     }
+
+    // MARK: - Picker ordering + localization key
+
+    func testAdaptive_IsFirstInAllCases() {
+        // Pickers iterate InputMethod.allCases in declaration order, so adaptive
+        // must be first to appear at the top of the list.
+        XCTAssertEqual(InputMethod.allCases.first, .adaptive)
+    }
+
+    func testAdaptive_RawValueStableForPersistence() {
+        // Reordering the declaration must NOT change the persisted rawValue.
+        XCTAssertEqual(InputMethod.adaptive.rawValue, 4)
+        XCTAssertEqual(InputMethod(rawValue: 4), .adaptive)
+    }
+
+    func testAdaptive_DisplayNameIsLocalizationSourceKey() {
+        // displayName is used as the Localizable.xcstrings key (sourceLanguage = vi).
+        XCTAssertEqual(InputMethod.adaptive.displayName, "Tự nhận kiểu gõ (Telex + VNI)")
+    }
+
+    // MARK: - Behavior edges
+
+    func testAdaptive_MixedModifiers_VniThenTelex() {
+        // a + 1 (VNI sắc → á) then f (Telex huyền) replaces the tone → à
+        XCTAssertEqual(typeAdaptive([
+            ("a", VietnameseData.KEY_A), ("1", VietnameseData.KEY_1), ("f", VietnameseData.KEY_F)
+        ]), "à")
+    }
+
+    func testAdaptive_BracketComposesHornInAdaptive() {
+        // Telex bracket standalone input must still work in adaptive: [ → ơ, ] → ư
+        XCTAssertEqual(typeAdaptive([("[", VietnameseData.KEY_LEFT_BRACKET)]), "ơ")
+        XCTAssertEqual(typeAdaptive([("]", VietnameseData.KEY_RIGHT_BRACKET)]), "ư")
+    }
+
+    func testAdaptive_Uppercase_BothWays() {
+        // Uppercase Á via Telex (A+s) and VNI (A+1)
+        func typeUpper(_ keys: [(Character, UInt16, Bool)]) -> String {
+            engine.reset()
+            engine.vAdaptiveEnabled = true
+            engine.vInputType = 0
+            for (ch, code, up) in keys {
+                _ = engine.processKey(character: ch, keyCode: code, isUppercase: up)
+            }
+            return engine.getCurrentWord()
+        }
+        XCTAssertEqual(typeUpper([("A", VietnameseData.KEY_A, true), ("s", VietnameseData.KEY_S, false)]), "Á")
+        XCTAssertEqual(typeUpper([("A", VietnameseData.KEY_A, true), ("1", VietnameseData.KEY_1, false)]), "Á")
+    }
 }

--- a/XKeyTests/VNEngineAdaptiveTests.swift
+++ b/XKeyTests/VNEngineAdaptiveTests.swift
@@ -130,7 +130,7 @@ class VNEngineAdaptiveTests: XCTestCase {
         let word = typeAdaptive([
             ("m", VietnameseData.KEY_M), ("p", VietnameseData.KEY_P), ("3", VietnameseData.KEY_3)
         ])
-        XCTAssertEqual(word, "mp3")
+        XCTAssertEqual(word, "mp3", "all-consonant + digit token must not be modified")
     }
 
     func testAdaptive_ValidVietnameseDigitStillWorks() {
@@ -186,7 +186,7 @@ class VNEngineAdaptiveTests: XCTestCase {
         XCTAssertEqual(engine.getCurrentWord(), "ô")
     }
 
-    func testAdaptive_BackspaceRevertsTone() {
+    func testAdaptive_BackspaceClearsComposedChar() {
         engine.reset()
         engine.vAdaptiveEnabled = true
         engine.vInputType = 0

--- a/XKeyTests/VNEngineAdaptiveTests.swift
+++ b/XKeyTests/VNEngineAdaptiveTests.swift
@@ -1,0 +1,55 @@
+//
+//  VNEngineAdaptiveTests.swift
+//  XKeyTests
+//
+//  Tests for the Adaptive input method (Telex + VNI auto-accept).
+//
+
+import XCTest
+@testable import XKey
+
+class VNEngineAdaptiveTests: XCTestCase {
+
+    var engine: VNEngine!
+
+    override func setUp() {
+        super.setUp()
+        engine = VNEngine()
+    }
+
+    override func tearDown() {
+        engine = nil
+        super.tearDown()
+    }
+
+    // MARK: - Task 1: enum + settings round-trip
+
+    func testAdaptiveEnumExists() {
+        XCTAssertEqual(InputMethod.adaptive.rawValue, 4)
+        XCTAssertFalse(InputMethod.adaptive.displayName.isEmpty)
+        XCTAssertTrue(InputMethod.allCases.contains(.adaptive))
+    }
+
+    func testAdaptiveSettingsRoundTrip() {
+        var settings = engine.settings
+        settings.inputMethod = .adaptive
+        engine.updateSettings(settings)
+
+        XCTAssertTrue(engine.vAdaptiveEnabled, "vAdaptiveEnabled should be set for .adaptive")
+        XCTAssertEqual(engine.vInputType, 0, "base vInputType should default to Telex (0)")
+        XCTAssertEqual(engine.settings.inputMethod, .adaptive, "reverse mapping should return .adaptive")
+    }
+
+    func testNonAdaptiveClearsFlag() {
+        var settings = engine.settings
+        settings.inputMethod = .adaptive
+        engine.updateSettings(settings)
+        XCTAssertTrue(engine.vAdaptiveEnabled)
+
+        settings.inputMethod = .vni
+        engine.updateSettings(settings)
+        XCTAssertFalse(engine.vAdaptiveEnabled, "switching to VNI must clear vAdaptiveEnabled")
+        XCTAssertEqual(engine.vInputType, 1)
+        XCTAssertEqual(engine.settings.inputMethod, .vni)
+    }
+}

--- a/XKeyTests/VNEngineAdaptiveTests.swift
+++ b/XKeyTests/VNEngineAdaptiveTests.swift
@@ -93,4 +93,25 @@ class VNEngineAdaptiveTests: XCTestCase {
         // VNI: d + 9  →  đ
         XCTAssertEqual(typeAdaptive([("d", VietnameseData.KEY_D), ("9", VietnameseData.KEY_9)]), "đ")
     }
+
+    // MARK: - Task 3: static gatekeepers accept adaptive keys
+
+    func testAdaptive_DigitIsSpecialKey() {
+        // Letters are always special; the point is digits must be special in adaptive.
+        XCTAssertTrue(VNEngine.isVietnameseSpecialKey(character: "1", inputMethod: .adaptive))
+        XCTAssertTrue(VNEngine.isVietnameseSpecialKey(character: "9", inputMethod: .adaptive))
+        // Telex modifier letters too:
+        XCTAssertTrue(VNEngine.isVietnameseSpecialKey(character: "s", inputMethod: .adaptive))
+        // Brackets are Telex standalone input → special in adaptive:
+        XCTAssertTrue(VNEngine.isVietnameseSpecialKey(character: "[", inputMethod: .adaptive))
+        XCTAssertTrue(VNEngine.isVietnameseSpecialKey(character: "]", inputMethod: .adaptive))
+    }
+
+    func testAdaptive_BracketIsNotWordBreak() {
+        // In Telex, [ and ] are NOT word breaks (they produce ơ/ư). Same for adaptive.
+        XCTAssertFalse(VNEngine.isWordBreak(character: "[", inputMethod: .adaptive))
+        XCTAssertFalse(VNEngine.isWordBreak(character: "]", inputMethod: .adaptive))
+        // Space is always a word break:
+        XCTAssertTrue(VNEngine.isWordBreak(character: " ", inputMethod: .adaptive))
+    }
 }

--- a/XKeyTests/VNEngineAdaptiveTests.swift
+++ b/XKeyTests/VNEngineAdaptiveTests.swift
@@ -114,4 +114,30 @@ class VNEngineAdaptiveTests: XCTestCase {
         // Space is always a word break:
         XCTAssertTrue(VNEngine.isWordBreak(character: " ", inputMethod: .adaptive))
     }
+
+    // MARK: - Task 4: alphanumeric / English tokens stay literal
+
+    func testAdaptive_CovidStaysLiteral() {
+        let word = typeAdaptive([
+            ("c", VietnameseData.KEY_C), ("o", VietnameseData.KEY_O), ("v", VietnameseData.KEY_V),
+            ("i", VietnameseData.KEY_I), ("d", VietnameseData.KEY_D),
+            ("1", VietnameseData.KEY_1), ("9", VietnameseData.KEY_9)
+        ])
+        XCTAssertEqual(word, "covid19", "non-Vietnamese token must not get VNI tones")
+    }
+
+    func testAdaptive_Mp3StaysLiteral() {
+        let word = typeAdaptive([
+            ("m", VietnameseData.KEY_M), ("p", VietnameseData.KEY_P), ("3", VietnameseData.KEY_3)
+        ])
+        XCTAssertEqual(word, "mp3")
+    }
+
+    func testAdaptive_ValidVietnameseDigitStillWorks() {
+        // Sanity: a valid syllable + VNI digit still gets the tone (gate must not over-block).
+        // v + i + 1 → ví
+        XCTAssertEqual(typeAdaptive([
+            ("v", VietnameseData.KEY_V), ("i", VietnameseData.KEY_I), ("1", VietnameseData.KEY_1)
+        ]), "ví")
+    }
 }


### PR DESCRIPTION
## Adaptive input: type Vietnamese in Telex or VNI without switching

  Adds a fifth input method, **Adaptive Input (Telex + VNI)**, that accepts both
  at once — `as` or `a1` both give `á`, `dd` or `d9` both give `đ`. No mode to pick.
  
<img width="302" height="302" alt="image" src="https://github.com/user-attachments/assets/7e917cbf-c79a-4d23-9d84-5ebce73bbcd8" />


  ### What changed

  - `VNCharacter.swift` — new `InputMethod.adaptive` (declared first so it sits at
    the top of the picker; raw value pinned to `4` so saved prefs stay valid)
  - `VNEngine.swift` — the per-keystroke effective-type line, plus `.adaptive` in
    the two static key gatekeepers
  - `VNEngineSettings.swift` — settings round-trip for the new mode
  - `InputProcessor.swift` — exhaustiveness for the new case
  - `Localizable.xcstrings` — vi (source) / en / zh-Hans for the option label
  - `VNEngineAdaptiveTests.swift` — 21 tests

  No changes to the Telex / VNI / Simple Telex transform logic itself.

  ### Test plan

  - [x] Same word in Telex vs VNI → identical output (9-glyph equivalence matrix)
  - [x] Mixed modifiers, brackets (`[`→ơ, `]`→ư), uppercase
  - [x] `covid19` / `mp3` stay literal; `ví` still gets its tone
  - [x] Picker ordering, settings round-trip, word-break, backspace
  - [x] Existing `VNEngineTests` still green (no regression to other modes)