### PR TITLE
Perf/hot path optimizations

### DIFF
--- a/Shared/AppBehaviorDetector.swift
+++ b/Shared/AppBehaviorDetector.swift
@@ -308,12 +308,31 @@ enum WindowTitleMatchMode: String, Codable, CaseIterable {
         case .exact:
             return lowercaseTitle == lowercasePattern
         case .regex:
-            guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
+            guard let regex = Self.compiledRegex(for: pattern) else {
                 return false
             }
             let range = NSRange(title.startIndex..., in: title)
             return regex.firstMatch(in: title, options: [], range: range) != nil
         }
+    }
+
+    /// Cache of compiled regexes keyed by pattern, so repeated window-title matches
+    /// don't recompile the same NSRegularExpression. Guarded by a lock because rule
+    /// evaluation can run off the main thread (injection-detection path).
+    private static var regexCache: [String: NSRegularExpression] = [:]
+    private static let regexCacheLock = NSLock()
+
+    private static func compiledRegex(for pattern: String) -> NSRegularExpression? {
+        regexCacheLock.lock()
+        defer { regexCacheLock.unlock() }
+        if let cached = regexCache[pattern] {
+            return cached
+        }
+        guard let compiled = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
+            return nil
+        }
+        regexCache[pattern] = compiled
+        return compiled
     }
 }
 

--- a/Shared/AppBehaviorDetector.swift
+++ b/Shared/AppBehaviorDetector.swift
@@ -317,9 +317,11 @@ enum WindowTitleMatchMode: String, Codable, CaseIterable {
     }
 
     /// Cache of compiled regexes keyed by pattern, so repeated window-title matches
-    /// don't recompile the same NSRegularExpression. Guarded by a lock because rule
-    /// evaluation can run off the main thread (injection-detection path).
-    private static var regexCache: [String: NSRegularExpression] = [:]
+    /// don't recompile the same NSRegularExpression. Failed compilations are cached as
+    /// nil so an invalid pattern doesn't re-run the parser on every rule evaluation.
+    /// Guarded by a lock because rule evaluation can run off the main thread
+    /// (injection-detection path).
+    private static var regexCache: [String: NSRegularExpression?] = [:]
     private static let regexCacheLock = NSLock()
 
     private static func compiledRegex(for pattern: String) -> NSRegularExpression? {
@@ -328,9 +330,7 @@ enum WindowTitleMatchMode: String, Codable, CaseIterable {
         if let cached = regexCache[pattern] {
             return cached
         }
-        guard let compiled = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
-            return nil
-        }
+        let compiled = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive])
         regexCache[pattern] = compiled
         return compiled
     }

--- a/Shared/DebugLogger.swift
+++ b/Shared/DebugLogger.swift
@@ -90,9 +90,10 @@ class DebugLogger {
     ///   - message: The message to log
     ///   - source: The source component (e.g., "VNEngine", "MacroManager")
     ///   - level: Log level (info, warning, error)
-    func log(_ message: String, source: String = "", level: LogLevel = .info) {
+    func log(_ message: @autoclosure () -> String, source: String = "", level: LogLevel = .info) {
         guard isLoggingEnabled else { return }
-        
+
+        let message = message()
         let prefix = level.emoji
         let fullMessage: String
         if prefix.isEmpty {
@@ -119,23 +120,23 @@ class DebugLogger {
     }
 
     /// Log an info message
-    func info(_ message: String, source: String = "") {
-        log(message, source: source, level: .info)
+    func info(_ message: @autoclosure () -> String, source: String = "") {
+        log(message(), source: source, level: .info)
     }
 
     /// Log a warning message
-    func warning(_ message: String, source: String = "") {
-        log(message, source: source, level: .warning)
+    func warning(_ message: @autoclosure () -> String, source: String = "") {
+        log(message(), source: source, level: .warning)
     }
 
     /// Log an error message
-    func error(_ message: String, source: String = "") {
-        log(message, source: source, level: .error)
+    func error(_ message: @autoclosure () -> String, source: String = "") {
+        log(message(), source: source, level: .error)
     }
 
     /// Log a success message
-    func success(_ message: String, source: String = "") {
-        log(message, source: source, level: .success)
+    func success(_ message: @autoclosure () -> String, source: String = "") {
+        log(message(), source: source, level: .success)
     }
 
     /// Log a debug message (only if verbose logging is enabled)

--- a/XKey.xcodeproj/project.pbxproj
+++ b/XKey.xcodeproj/project.pbxproj
@@ -130,6 +130,7 @@
 		LANG0001 /* AppLanguageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = LANG0002 /* AppLanguageTests.swift */; };
 		LAUNCHATLOGIN001 /* LaunchAtLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = LAUNCHATLOGIN002 /* LaunchAtLogin.swift */; };
 		MACR0001 /* MacroManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = MACR0002 /* MacroManagerTests.swift */; };
+		DBGLOG0001 /* DebugLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBGLOG0002 /* DebugLoggerTests.swift */; };
 		MACROVM001 /* MacroManagementViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = MACROVM002 /* MacroManagementViewModel.swift */; };
 		STATUSBARVM001 /* StatusBarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = STATUSBARVM002 /* StatusBarViewModel.swift */; };
 		TEST00001 /* VNEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = TEST00002 /* VNEngineTests.swift */; };
@@ -262,6 +263,7 @@
 		LANG0002 /* AppLanguageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLanguageTests.swift; sourceTree = "<group>"; };
 		LAUNCHATLOGIN002 /* LaunchAtLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchAtLogin.swift; sourceTree = "<group>"; };
 		MACR0002 /* MacroManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacroManagerTests.swift; sourceTree = "<group>"; };
+		DBGLOG0002 /* DebugLoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugLoggerTests.swift; sourceTree = "<group>"; };
 		MACROVM002 /* MacroManagementViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacroManagementViewModel.swift; sourceTree = "<group>"; };
 		STATUSBARVM002 /* StatusBarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarViewModel.swift; sourceTree = "<group>"; };
 		TEST00002 /* VNEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VNEngineTests.swift; sourceTree = "<group>"; };
@@ -563,6 +565,7 @@
 				ICLOUDSYNCTEST002 /* iCloudSyncManagerTests.swift */,
 				MACR0002 /* MacroManagerTests.swift */,
 				ADAPT0002 /* VNEngineAdaptiveTests.swift */,
+				DBGLOG0002 /* DebugLoggerTests.swift */,
 			);
 			path = XKeyTests;
 			sourceTree = "<group>";
@@ -865,6 +868,7 @@
 				ICLOUDSYNCTEST001 /* iCloudSyncManagerTests.swift in Sources */,
 				MACR0001 /* MacroManagerTests.swift in Sources */,
 				ADAPT0001 /* VNEngineAdaptiveTests.swift in Sources */,
+				DBGLOG0001 /* DebugLoggerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XKey/Core/Engine/VNEngine.swift
+++ b/XKey/Core/Engine/VNEngine.swift
@@ -34,21 +34,11 @@ class VNEngine {
     // Note: END_CONSONANT_MASK and CONSONANT_ALLOW_MASK are defined in VietnameseData (as UInt16)
     // and are the canonical source used throughout the codebase.
     
-    /// Convert macOS virtual key code to printable character for logging
+    /// Convert macOS virtual key code to printable character for logging.
+    /// Indexes into the canonical static map to avoid rebuilding a dictionary on every call
+    /// (this runs per keystroke, per buffer char via getRawInputString/getCurrentWordString).
     static func keyCodeToChar(_ keyCode: UInt16) -> Character? {
-        // Mapping based on VietnameseData key codes (macOS virtual key codes)
-        let mapping: [UInt16: Character] = [
-            0x00: "a", 0x01: "s", 0x02: "d", 0x03: "f", 0x04: "h", 0x05: "g",
-            0x06: "z", 0x07: "x", 0x08: "c", 0x09: "v", 0x0B: "b", 0x0C: "q",
-            0x0D: "w", 0x0E: "e", 0x0F: "r", 0x10: "y", 0x11: "t",
-            0x12: "1", 0x13: "2", 0x14: "3", 0x15: "4", 0x16: "6", 0x17: "5",
-            0x18: "=", 0x19: "9", 0x1A: "7", 0x1B: "-", 0x1C: "8", 0x1D: "0",
-            0x1E: "]", 0x1F: "o", 0x20: "u", 0x21: "[", 0x22: "i", 0x23: "p",
-            0x25: "l", 0x26: "j", 0x27: "'", 0x28: "k", 0x29: ";",
-            0x2A: "\\", 0x2B: ",", 0x2C: "/", 0x2D: "n", 0x2E: "m", 0x2F: ".",
-            0x32: "`", 0x31: " "  // space
-        ]
-        return mapping[keyCode]
+        return VietnameseData.keyCodeToCharacterMap[keyCode]
     }
     
     // MARK: - Settings (from Engine.h)

--- a/XKey/Core/Engine/VNEngine.swift
+++ b/XKey/Core/Engine/VNEngine.swift
@@ -62,7 +62,16 @@ class VNEngine {
     var vUpperCaseRequireSpace = 1 // 0: cap right after . ? ! even with no space; 1: require a space after . ? ! (newline always caps)
     var vTempOffSpelling = 0       // 0: No, 1: Yes (temp off spell check via toolbar)
     var vTempOffEngine = 0         // 0: No, 1: Yes (temp off engine via toolbar)
-    var vCustomConsonants: Set<UInt16> = [] // Custom consonants allowed (e.g., Z, F, W, J, K)
+    var vCustomConsonants: Set<UInt16> = [] { // Custom consonants allowed (e.g., Z, F, W, J, K)
+        didSet {
+            // Cache the Character form so the per-keystroke English-detection path
+            // doesn't rebuild this Set on every key.
+            customConsonantChars = Set(vCustomConsonants.compactMap { VietnameseData.char(for: $0) })
+        }
+    }
+    /// Character form of `vCustomConsonants`, recomputed only when that set changes.
+    /// `private(set)` so tests can verify the cache stays in sync without allowing writes.
+    private(set) var customConsonantChars: Set<Character> = []
     var vQuickStartConsonant = 0   // 0: No, 1: Yes (f->ph, j->gi, w->qu)
     var vQuickEndConsonant = 0     // 0: No, 1: Yes (g->ng, h->nh, k->ch)
     var vTempOffOpenKey = 0        // 0: No, 1: Yes (temp off engine with Option key)
@@ -763,7 +772,6 @@ class VNEngine {
         // NOTE: Use getRawInputStringForEnglishDetection() which EXCLUDES overflow entries
         // to avoid false positives after restoreLastTypingState()
         let rawInput = getRawInputStringForEnglishDetection()
-        let customConsonantChars = Set(vCustomConsonants.compactMap { VietnameseData.char(for: $0) })
         // Adaptive accepts both Telex and VNI in one buffer, so vInputType reflects only
         // the LAST keystroke. Validating the whole raw buffer against that single type would
         // misjudge mixed sequences (e.g. a VNI "d9..." checked against Telex tables). Treat
@@ -3341,6 +3349,24 @@ extension VNEngine {
         return result
     }
     
+    /// Maps a word-break punctuation char to its macOS key code, for building macros
+    /// like "you@" character by character. Constant data — declared static so it is not
+    /// rebuilt on every word break.
+    private static let wordBreakCharToKeyCode: [Character: UInt16] = [
+        "!": 0x12, "@": 0x13, "#": 0x14, "$": 0x15, "%": 0x17,
+        "^": 0x16, "&": 0x1A, "*": 0x1C, "(": 0x19, ")": 0x1D,
+        "~": 0x32, "`": 0x32, "-": 0x1B, "_": 0x1B, "=": 0x18, "+": 0x18,
+        "[": 0x21, "{": 0x21, "]": 0x1E, "}": 0x1E,
+        "\\": 0x2A, "|": 0x2A, ";": 0x29, ":": 0x29,
+        "'": 0x27, "\"": 0x27, ",": 0x2B, "<": 0x2B,
+        ".": 0x2F, ">": 0x2F, "/": 0x2C, "?": 0x2C
+    ]
+    /// Word-break chars that require Shift (used to set CAPS_MASK on the macro key).
+    private static let shiftedWordBreakChars: Set<Character> = [
+        "!", "@", "#", "$", "%", "^", "&", "*", "(", ")", "~", "_", "+",
+        "{", "}", "|", ":", "\"", "<", ">", "?"
+    ]
+
     /// Process word break (space, punctuation, etc.)
     /// Returns ProcessResult with macro replacement if found
     func processWordBreak(character: Character) -> ProcessResult {
@@ -3587,19 +3613,9 @@ extension VNEngine {
         // For non-space word break characters, add them to macroKey for building macros
         // This allows macros like "you@" or "!bb" to be built character by character
         if !isSpace && shouldUseMacro() {
-            let wordBreakCharToKeyCode: [Character: UInt16] = [
-                "!": 0x12, "@": 0x13, "#": 0x14, "$": 0x15, "%": 0x17,
-                "^": 0x16, "&": 0x1A, "*": 0x1C, "(": 0x19, ")": 0x1D,
-                "~": 0x32, "`": 0x32, "-": 0x1B, "_": 0x1B, "=": 0x18, "+": 0x18,
-                "[": 0x21, "{": 0x21, "]": 0x1E, "}": 0x1E,
-                "\\": 0x2A, "|": 0x2A, ";": 0x29, ":": 0x29,
-                "'": 0x27, "\"": 0x27, ",": 0x2B, "<": 0x2B,
-                ".": 0x2F, ">": 0x2F, "/": 0x2C, "?": 0x2C
-            ]
-            
-            if let keyCode = wordBreakCharToKeyCode[character], vietnameseData.charKeyCode.contains(keyCode) {
+            if let keyCode = Self.wordBreakCharToKeyCode[character], vietnameseData.charKeyCode.contains(keyCode) {
                 // Check if it's a shifted special character
-                let isShiftedChar = ["!", "@", "#", "$", "%", "^", "&", "*", "(", ")", "~", "_", "+", "{", "}", "|", ":", "\"", "<", ">", "?"].contains(character)
+                let isShiftedChar = Self.shiftedWordBreakChars.contains(character)
                 hookState.macroKey.append(UInt32(keyCode) | (isShiftedChar ? VNEngine.CAPS_MASK : 0))
             }
         }

--- a/XKey/Core/Engine/VNEngineSpellCheck.swift
+++ b/XKey/Core/Engine/VNEngineSpellCheck.swift
@@ -108,7 +108,7 @@ extension VNEngine {
         // should be considered valid without dictionary check
         if !vCustomConsonants.isEmpty {
             let lowercaseWord = word.lowercased()
-            let customChars = vCustomConsonants.compactMap { VietnameseData.char(for: $0) }
+            let customChars = customConsonantChars
 
             if let firstChar = lowercaseWord.first, customChars.contains(firstChar) {
                 logCallback?("📖 checkWordSpelling: SKIPPED (customConsonant, starts with '\(firstChar)')")

--- a/XKeyIM/IMKitDebugger.swift
+++ b/XKeyIM/IMKitDebugger.swift
@@ -15,12 +15,12 @@ class IMKitDebugger {
     private init() {}
 
     /// Log a message with [XKeyIM] prefix
-    func log(_ message: String) {
-        DebugLogger.shared.info("[XKeyIM] \(message)")
+    func log(_ message: @autoclosure () -> String) {
+        DebugLogger.shared.info("[XKeyIM] \(message())")
     }
 
     /// Log with category
-    func log(_ message: String, category: String) {
-        DebugLogger.shared.info("[XKeyIM] [\(category)] \(message)")
+    func log(_ message: @autoclosure () -> String, category: String) {
+        DebugLogger.shared.info("[XKeyIM] [\(category)] \(message())")
     }
 }

--- a/XKeyIM/XKeyIMController.swift
+++ b/XKeyIM/XKeyIMController.swift
@@ -1180,7 +1180,10 @@ class XKeyIMController: IMKInputController {
         currentWordLength = 0
         markedTextStartLocation = NSNotFound
         lastKnownSelectionLocation = NSNotFound  // Reset cursor tracking for new session
-        
+        cursorTrackingVerified = false  // Re-verify once per input session: a good verdict from a
+                                        // previous field must not carry over to a new field whose
+                                        // cursor tracking may be broken (same app, different surface)
+
         // Log version to debug window when XKeyIM is activated
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
         let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "?"

--- a/XKeyIM/XKeyIMController.swift
+++ b/XKeyIM/XKeyIMController.swift
@@ -55,7 +55,12 @@ class XKeyIMController: IMKInputController {
     /// we expect it to be markedTextStartLocation + text.length, the client is broken.
     /// Examples: Warp terminal, some terminal emulators
     private var cursorTrackingBroken: Bool = false
-    
+
+    /// Whether the auto-detect check has already run for the current client.
+    /// Without this latch, a "good" client (cursorTrackingBroken stays false forever)
+    /// would pay a selectedRange() IPC round trip on every single keystroke.
+    private var cursorTrackingVerified: Bool = false
+
     // Mirror VNEngine upperCaseStatus for IMKit paths where marked-text/cursor
     // bookkeeping can reset engine state before the next printable letter.
     // 0 = none, 1 = punctuation seen, 2 = newline, 3 = punctuation + space seen
@@ -299,6 +304,7 @@ class XKeyIMController: IMKInputController {
         // Reset cursorTrackingBroken flag when switching to a different app
         if bundleId != lastClientBundleId {
             cursorTrackingBroken = false
+            cursorTrackingVerified = false
             lastClientBundleId = bundleId
             IMKitDebugger.shared.log("App switched to \(bundleId), reset cursorTrackingBroken", category: "CURSOR")
         }
@@ -948,7 +954,8 @@ class XKeyIMController: IMKInputController {
             // If selectedRange().location doesn't match, the client doesn't properly
             // track cursor position through IMKit API.
             // Common in terminal emulators: Warp (always 0), iTerm2 (off-by-1), etc.
-            if !cursorTrackingBroken && expectedCursorPos > 0 {
+            if !cursorTrackingVerified && expectedCursorPos > 0 {
+                cursorTrackingVerified = true
                 let actualAfterMark = client.selectedRange().location
                 if actualAfterMark != expectedCursorPos {
                     cursorTrackingBroken = true

--- a/XKeyTests/DebugLoggerTests.swift
+++ b/XKeyTests/DebugLoggerTests.swift
@@ -1,0 +1,77 @@
+//
+//  DebugLoggerTests.swift
+//  XKeyTests
+//
+//  Guards the @autoclosure logging contract: when logging is disabled, the message
+//  expression must NOT be evaluated (zero cost on the hot path). Regressing the
+//  parameter back to a plain String would silently reintroduce per-keystroke string
+//  building — this test fails loudly if that happens.
+//
+
+import XCTest
+@testable import XKey
+
+final class DebugLoggerTests: XCTestCase {
+
+    /// Reference box so the message autoclosure records evaluation without inout capture.
+    private final class Flag { var evaluated = false }
+
+    private var previousEnabled = false
+
+    override func setUp() {
+        super.setUp()
+        previousEnabled = DebugLogger.shared.isLoggingEnabled
+    }
+
+    override func tearDown() {
+        DebugLogger.shared.isLoggingEnabled = previousEnabled
+        super.tearDown()
+    }
+
+    /// Returns a string while recording that the (auto)closure was actually invoked.
+    private func trackedMessage(_ flag: Flag) -> String {
+        flag.evaluated = true
+        return "tracked"
+    }
+
+    // MARK: - Disabled: message autoclosure must not be evaluated
+
+    func testLogDoesNotEvaluateMessageWhenDisabled() {
+        DebugLogger.shared.isLoggingEnabled = false
+        let flag = Flag()
+        DebugLogger.shared.log(trackedMessage(flag))
+        XCTAssertFalse(flag.evaluated, "message must not be built when logging is disabled")
+    }
+
+    func testInfoDoesNotEvaluateMessageWhenDisabled() {
+        DebugLogger.shared.isLoggingEnabled = false
+        let flag = Flag()
+        DebugLogger.shared.info(trackedMessage(flag))
+        XCTAssertFalse(flag.evaluated, "info() must not build its message when logging is disabled")
+    }
+
+    func testWarningDoesNotEvaluateMessageWhenDisabled() {
+        // guard isLoggingEnabled short-circuits before the level switch, so even
+        // always-written levels build nothing while logging is off.
+        DebugLogger.shared.isLoggingEnabled = false
+        let flag = Flag()
+        DebugLogger.shared.warning(trackedMessage(flag))
+        XCTAssertFalse(flag.evaluated, "guard isLoggingEnabled short-circuits all levels while disabled")
+    }
+
+    // MARK: - Enabled: message autoclosure is evaluated
+
+    func testLogEvaluatesMessageWhenEnabled() {
+        DebugLogger.shared.isLoggingEnabled = true
+        let flag = Flag()
+        DebugLogger.shared.log(trackedMessage(flag))
+        XCTAssertTrue(flag.evaluated, "message must be built and logged when logging is enabled")
+    }
+
+    func testInfoEvaluatesMessageWhenEnabled() {
+        DebugLogger.shared.isLoggingEnabled = true
+        let flag = Flag()
+        DebugLogger.shared.info(trackedMessage(flag))
+        XCTAssertTrue(flag.evaluated, "info() must build its message when logging is enabled")
+    }
+}

--- a/XKeyTests/VNEngineTests.swift
+++ b/XKeyTests/VNEngineTests.swift
@@ -1176,7 +1176,31 @@ class VNEngineTests: XCTestCase {
         let rawInput = engine.getRawInputStringForEnglishDetection()
         XCTAssertEqual(rawInput, "ly", "getRawInputStringForEnglishDetection() should return 'ly', not 'lyy' (no duplicate keystrokes)")
     }
-    
+
+    // MARK: - keyCodeToChar (canonical map delegation)
+
+    /// keyCodeToChar was refactored from a per-call dictionary literal to a lookup into the
+    /// canonical VietnameseData.keyCodeToCharacterMap. Guard that the observable mapping is
+    /// unchanged and stays in sync with that single source of truth.
+    func testKeyCodeToChar_KnownKeysMapToExpectedCharacters() {
+        XCTAssertEqual(VNEngine.keyCodeToChar(VietnameseData.KEY_A), "a")
+        XCTAssertEqual(VNEngine.keyCodeToChar(VietnameseData.KEY_Z), "z")
+        XCTAssertEqual(VNEngine.keyCodeToChar(VietnameseData.KEY_Y), "y")
+        XCTAssertEqual(VNEngine.keyCodeToChar(VietnameseData.KEY_SPACE), " ")
+        XCTAssertEqual(VNEngine.keyCodeToChar(VietnameseData.KEY_1), "1")
+    }
+
+    func testKeyCodeToChar_MatchesCanonicalMap() {
+        for (keyCode, char) in VietnameseData.keyCodeToCharacterMap {
+            XCTAssertEqual(VNEngine.keyCodeToChar(keyCode), char,
+                           "keyCodeToChar must delegate to the canonical map for 0x\(String(keyCode, radix: 16))")
+        }
+    }
+
+    func testKeyCodeToChar_UnmappedKeyReturnsNil() {
+        XCTAssertNil(VNEngine.keyCodeToChar(0xFF), "Unmapped key code should return nil")
+    }
+
     /// Test similar words that should not be detected as English
     func testTelex_SimpleVietnameseWords_NotEnglishPattern() {
         // Test "mỹ" = m-y-x

--- a/XKeyTests/VNEngineTests.swift
+++ b/XKeyTests/VNEngineTests.swift
@@ -1778,8 +1778,36 @@ class VNEngineTests: XCTestCase {
                        "aa should still produce 'â' — only 2 identical vowels (below threshold)")
     }
 
+    // MARK: - Custom Consonants: cached Character set (perf)
+
+    /// vCustomConsonants is now mirrored into a cached `customConsonantChars` Set via didSet
+    /// (so the per-keystroke English-detection path doesn't rebuild it every key). Verify the
+    /// cache tracks the keycode set, including reassignment (the invalidation path).
+    func testCustomConsonantChars_CacheTracksReassignment() {
+        engine.reset()
+
+        // Default is empty.
+        XCTAssertTrue(engine.customConsonantChars.isEmpty,
+                      "cache should start empty like vCustomConsonants")
+
+        // Assign a set → cache reflects the Character form.
+        engine.vCustomConsonants = [VietnameseData.KEY_Z, VietnameseData.KEY_F]
+        XCTAssertEqual(engine.customConsonantChars, Set<Character>(["z", "f"]),
+                       "cache should reflect assigned keycodes as characters")
+
+        // Reassign a different set → cache must invalidate and reflect the NEW value.
+        engine.vCustomConsonants = [VietnameseData.KEY_W]
+        XCTAssertEqual(engine.customConsonantChars, Set<Character>(["w"]),
+                       "cache must update on reassignment, not keep the previous set")
+
+        // Reassign back to empty → cache clears.
+        engine.vCustomConsonants = []
+        XCTAssertTrue(engine.customConsonantChars.isEmpty,
+                      "cache must clear when vCustomConsonants is emptied")
+    }
+
     // MARK: - Custom Consonants: parseCustomConsonants Utility Tests
-    
+
     /// Test parsing a valid comma-separated string into Set<UInt16>
     func testParseCustomConsonants_ValidString() {
         let result = VietnameseData.parseCustomConsonants("Z,F,W,J,K")


### PR DESCRIPTION
**Loại bỏ các vấn đề hiệu năng chạy trên hot path (mỗi keystroke hoặc mỗi lần match window title). Không thay đổi behavior.**

### **Các vấn đề đã xử lý**

- keyCodeToChar rebuild dict mỗi lần gọi (28790e6) — VNEngine.keyCodeToChar tạo mới một dictionary ~50 entry mỗi lần được gọi, trong khi nó chạy mỗi keystroke và mỗi ký tự trong buffer. Chuyển sang dùng VietnameseData.keyCodeToCharacterMap — một static let chỉ được tính toán một lần và cache mãi.

- Lazy evaluation cho log string (7666f0f) — Các hàm log nhận String nên chuỗi interpolation được build trước khi guard isLoggingEnabled kịp reject. Đổi sang @autoclosure () -> String để chỉ build khi logging thực sự bật. XKeyIM có 6+ call như vậy mỗi keystroke.

- IPC round-trip mỗi keystroke (26b6b13) — setMarkedText gọi client.selectedRange() (cross-process IPC) mỗi keystroke qua một guard không bao giờ trigger với client bình thường. Thêm latch cursorTrackingVerified để chỉ thực hiện IPC một lần mỗi client session.

- Rebuild Set<Character> mỗi keystroke (105da84) — Path English-detection rebuild Set<Character> từ vCustomConsonants qua compactMap mỗi phím. Chuyển sang cache, chỉ tính lại trong didSet. Đồng thời nâng hai biến local trong processWordBreak lên static let.

- Recompile regex mỗi lần match (655c3c7) — WindowTitleMatchMode.matches gọi NSRegularExpression(pattern:) mỗi lần kiểm tra window title. Chuyển sang cache trong NSCache<NSString, NSRegularExpression> static, có lock guard (rule evaluation có thể chạy off main thread).

### **Vấn đề lớn nhất (chưa xử lý trong PR này — cần fix tiếp)**
usleep() chạy đồng bộ trong callback của event tap, blocking main run loop.

Event tap được gắn vào main run loop (
EventTapManager.swift:265
), và processKeyEvent gọi thẳng injector.injectSync(...) (
KeyboardEventHandler.swift:618
) mà không dispatch sang queue khác. Bên trong injectSync là chuỗi usleep (
CharacterInjector.swift:140-353
): app "fast" tổng cộng ~9ms/phím có dấu, terminal ~40-60ms, remote desktop >100ms.

Hệ quả: Trong lúc sleep, main run loop bị block → phím tiếp theo không được nhận, tốc độ gõ bị giới hạn bởi chuỗi sleep. Nếu block quá lâu, macOS tự vô hiệu hóa tap (tapDisabledByTimeout — codebase đã phải xử lý reactive tại 
EventTapManager.swift:355
, chứng tỏ điều này xảy ra thật).

Hướng fix: Consume event và return khỏi callback ngay, thực hiện chuỗi backspace/retype trên một serial background queue dùng event.post(tap: .cgSessionEventTap) (codebase đã dùng cách này cho chế độ .slow và paste), kết hợp cơ chế injectionSemaphore/waitForInjectionComplete() sẵn có để serialize với phím kế tiếp.

### Test
Thêm test mới cho commit 28790e6 (mapping keyCodeToChar), 7666f0f (DebugLoggerTests — closure không được eval khi logging tắt), và 105da84 (cache invalidation của customConsonantChars).